### PR TITLE
Jiaming ground filter

### DIFF
--- a/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
@@ -70,6 +70,7 @@ private:
 
     size_t orig_index;  // index of this point in the source pointcloud
     pcl::PointXYZ * orig_point;
+    float corrected_Z; // Z coordinate if ground level is 0 (instead of lidar mounting level being zero)
   };
   using PointCloudRefVector = std::vector<PointRef>;
 

--- a/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
@@ -176,6 +176,8 @@ private:
   size_t radial_dividers_num_;
   VehicleInfo vehicle_info_;
   double ground_blindspot_;
+  double lidar_height_above_base_link_;
+  double wheel_radius_;
 
   /*!
    * Output transformed PointCloud from in_cloud_ptr->header.frame_id to in_target_frame

--- a/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
@@ -175,6 +175,7 @@ private:
   bool use_recheck_ground_cluster_;  // to enable recheck ground cluster
   size_t radial_dividers_num_;
   VehicleInfo vehicle_info_;
+  double ground_blindspot_;
 
   /*!
    * Output transformed PointCloud from in_cloud_ptr->header.frame_id to in_target_frame

--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -312,7 +312,7 @@ void ScanGroundFilterComponent::classifyPointCloudGridScan(
 
     bool initialized_first_gnd_grid = false;
     bool prev_list_init = false;
-    //Jiaming: only use corrected Z for global scope calculation and comparing to non_ground_hright_threshold
+    // only use corrected Z for global scope calculation and comparing to non_ground_hright_threshold
     // and add the corrected z value to ground_cluster
     // this change only in effect when using elevation_grid_mode
     for (size_t j = 0; j < in_radial_ordered_clouds[i].size(); ++j) {
@@ -323,7 +323,7 @@ void ScanGroundFilterComponent::classifyPointCloudGridScan(
         non_ground_height_threshold_local =
           non_ground_height_threshold_ * abs(p->orig_point->x / low_priority_region_x_);
       }
-      // Jiaming: if too close, lidar will not pickup the ground at all, so don't do ground filtering at all
+      // if too close, lidar will not pickup the ground at all, so don't do ground filtering at all
       if (p->radius < ground_blindspot_){
         p->point_state = PointLabel::NON_GROUND;
         out_no_ground_indices.indices.push_back(p->orig_index);
@@ -453,11 +453,10 @@ void ScanGroundFilterComponent::classifyPointCloud(
       const float local_slope_max_angle = local_slope_max_angle_rad_;
       auto * p = &in_radial_ordered_clouds[i][j];
       auto * p_prev = &in_radial_ordered_clouds[i][j - 1];
-      // Jiaming: if too close, lidar will not pickup the ground at all, so don't do ground filtering at all
+      // if too close, lidar will not pickup the ground at all, so don't do ground filtering at all
       if (p->radius < ground_blindspot_){
         p->point_state = PointLabel::NON_GROUND;
         out_no_ground_indices.indices.push_back(p->orig_index);
-        //prev_p = p;
         continue;
       }
       if (j == 0) {


### PR DESCRIPTION
ground filtering updates: solved issue that opponent car can't be seen when behind or beside due to overly aggressive ground filtering, solutions implemented (mostly implemented in this repo's ground_segmentation package, its corresponding launch and param files changed in IAC_Perception): 
    (a), set a radius corresponding to ground detection blindspot, everything inside classify as non-ground
    (b), separate the pre processing param files for front and side lidars, and tune the side lidar parameters, specifically reduce global slope threshold
    (c) shift the ground's zero on z axis to be the actual ground instead of lidar mounting height (independent of tf)
