### PR TITLE
fixed bug about clustering params not passed in from param file in mu…

### DIFF
--- a/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
+++ b/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
@@ -23,12 +23,17 @@ namespace euclidean_cluster
 EuclideanClusterNode::EuclideanClusterNode(const rclcpp::NodeOptions & options)
 : Node("euclidean_cluster_node", options)
 {
-  const bool use_height = this->declare_parameter("use_height", false);
-  const int min_cluster_size = this->declare_parameter("min_cluster_size", 3);
-  const int max_cluster_size = this->declare_parameter("max_cluster_size", 200);
-  const float tolerance = this->declare_parameter("tolerance", 1.0);
+  use_height_ = this->declare_parameter("use_height", false);
+  min_cluster_size_ = this->declare_parameter("min_cluster_size", 3);
+  max_cluster_size_ = this->declare_parameter("max_cluster_size", 200);
+  tolerance_ = this->declare_parameter("tolerance", 1.0);
+  // grab input from multi_car_tracker/param/tracker_preprocessor.param.yaml to overwrite default values above
+  this->get_parameter("use_height", use_height_); 
+  this->get_parameter("min_cluster_size", min_cluster_size_); 
+  this->get_parameter("max_cluster_size", max_cluster_size_); 
+  this->get_parameter("tolerance", tolerance_); 
   cluster_ =
-    std::make_shared<EuclideanCluster>(use_height, min_cluster_size, max_cluster_size, tolerance);
+    std::make_shared<EuclideanCluster>(use_height_, min_cluster_size_, max_cluster_size_, tolerance_);
 
   using std::placeholders::_1;
   pointcloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(

--- a/perception/euclidean_cluster/src/euclidean_cluster_node.hpp
+++ b/perception/euclidean_cluster/src/euclidean_cluster_node.hpp
@@ -34,6 +34,10 @@ public:
   explicit EuclideanClusterNode(const rclcpp::NodeOptions & options);
 
 private:
+  bool use_height_;
+  int min_cluster_size_;
+  int max_cluster_size_;
+  float tolerance_;
   void onPointCloud(sensor_msgs::msg::PointCloud2::ConstSharedPtr input_msg);
 
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_sub_;


### PR DESCRIPTION
fixed the bug that euclidean clustering parameters are not being passing in from multi_car_tracker/param/tracker_preprocessor.param.yaml. 
The params in that file should produce fewer clusters (with larger min_cluster_size=20 and larger max_cluster_size=5000 ande higher tolerance=2.0m) than the default hardcoded params in the node currently. 
Hope this could reduce the number of clusters the stack have to output which reduce the CPU load. (experiment shown a slight reduction on ADLink, not very significant though, but this is regardless a bug that need to be fixed even if can't reduce load)
