### PR TITLE
multi_object_tracker: skip yaw association gate for orientation-unavailable detections

### DIFF
--- a/perception/multi_object_tracker/src/data_association/data_association.cpp
+++ b/perception/multi_object_tracker/src/data_association/data_association.cpp
@@ -186,8 +186,12 @@ Eigen::MatrixXd DataAssociation::calcScoreMatrix(
           const double area = tier4_autoware_utils::getArea(measurement_object.shape);
           if (area < min_area || max_area < area) passed_gate = false;
         }
-        // angle gate
-        if (passed_gate) {
+        // angle gate: skipped when the measurement carries no orientation — such
+        // detections hold an identity quaternion, so a yaw comparison is meaningless
+        const bool measurement_has_orientation =
+          measurement_object.kinematics.orientation_availability !=
+          autoware_auto_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
+        if (passed_gate && measurement_has_orientation) {
           const double max_rad = max_rad_matrix_(tracker_label, measurement_label);
           const double angle = getFormedYawAngle(
             measurement_object.kinematics.pose_with_covariance.pose.orientation,


### PR DESCRIPTION
The data association angle gate compares the track's estimated heading against the measurement quaternion without checking `orientation_availability`. Detections that declare orientation UNAVAILABLE (e.g. camera point detections — position-only, identity quaternion) get yaw-gated against that placeholder: once a track's heading estimate converges more than `max_rad` away from zero (mod 180°), association becomes structurally impossible — the track coasts, its covariance blows up, and it dies, with a fresh short-lived track repeating the cycle.

Observed on the IAC vehicle with camera reprojection detections (Putnam run5 replay): 20 track ids at ~1 s median lifetime over an 11 s close pass, zero stable output, while the detections themselves were sub-meter accurate against a GPS reference.

Change: skip the angle gate when the measurement's `orientation_availability == UNAVAILABLE`; `SIGN_UNKNOWN` and `AVAILABLE` keep the existing behavior. Distance, area, Mahalanobis and IoU gates unchanged, so yaw-bearing detections (lidar/radar shape fits) are unaffected.

Validation (camera-only replays, tracker + lane_keeper + adapter downstream): pass window 58 → 168 published rows, 3.59 → 1.74 m median vs the GPS reference, single track through closest approach at 6 m range; a config-wide yaw-gate-off experiment produced identical camera results, confirming the scoped guard captures the full benefit. Related: airacingtech/IAC_Perception#72, airacingtech/art#957.