### PR TITLE
Harden camera tracking against depth jumps

### DIFF
--- a/perception/autoware_multi_object_tracker/CMakeLists.txt
+++ b/perception/autoware_multi_object_tracker/CMakeLists.txt
@@ -106,8 +106,11 @@ if(BUILD_TESTING)
     test/test_utils.cpp
     test/test_bench_association.cpp
     test/test_vehicle_tracker.cpp
+    test/test_detection_subscription_qos.cpp
     test/test_uuid_generator.cpp
     test/test_tracker_overlap_manager.cpp
+    test/test_birth_guard.cpp
+    test/test_input_manager.cpp
   )
   add_definitions(-D_SRC_RESOURCES_DIR_PATH="${PROJECT_SOURCE_DIR}/test/data/")
   ament_add_ros_isolated_gtest(test_multi_object_tracker ${test_files})

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/multiple_vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/multiple_vehicle_tracker.hpp
@@ -99,11 +99,15 @@ public:
 
   virtual ~MultipleVehicleTracker() {}
 
-  // Same policy as VehicleTracker: bicycle model owns shape; clusters use conditioned update.
+  // Same policy as VehicleTracker: a trustworthy object center is independent
+  // of extension trust; partial clusters use conditioned edge updates.
   UpdatePath selectUpdatePath(
-    bool trust_extension, bool has_significant_shape_change) const override
+    const types::InputChannel & channel_info, bool has_significant_shape_change) const override
   {
-    if (!trust_extension) return UpdatePath::CONDITIONED;
+    if (channel_info.trust_position_as_center && !channel_info.trust_extension) {
+      return UpdatePath::CENTER_POSITION;
+    }
+    if (!channel_info.trust_extension) return UpdatePath::CONDITIONED;
     return has_significant_shape_change ? UpdatePath::TRY_EXTENSION : UpdatePath::NORMAL;
   }
 };

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/tracker_base.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/tracker_base.hpp
@@ -43,7 +43,7 @@
 namespace autoware::multi_object_tracker
 {
 
-enum class UpdatePath { NORMAL, TRY_EXTENSION, CONDITIONED };
+enum class UpdatePath { NORMAL, CENTER_POSITION, TRY_EXTENSION, CONDITIONED };
 
 class Tracker
 {
@@ -53,6 +53,7 @@ private:
   int total_no_measurement_count_;
   int total_measurement_count_;
   rclcpp::Time last_update_with_measurement_time_;
+  rclcpp::Time last_existence_probability_update_time_;
   std::vector<types::ExistenceProbability> existence_probabilities_;
   float total_existence_probability_;
   std::vector<classes::Classification> classification_;
@@ -250,11 +251,14 @@ protected:
 
   // Selects the update path for a given measurement.
   // NORMAL      — standard Kalman update (with optional shape-filter history accumulation)
+  // CENTER_POSITION — consume only the center-pose kinematics; do not mutate extension trust or
+  //                   shape-filter history
   // TRY_EXTENSION — attempt extension update via shape filter; fall back to CONDITIONED if unstable
   // CONDITIONED — edge-aligned / weak conditioned update; shape management is bypassed entirely
-  virtual UpdatePath selectUpdatePath(bool trust_extension, bool has_significant_shape_change) const
+  virtual UpdatePath selectUpdatePath(
+    const types::InputChannel & channel_info, bool has_significant_shape_change) const
   {
-    (void)trust_extension;
+    (void)channel_info;
     (void)has_significant_shape_change;
     return UpdatePath::NORMAL;
   }

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
@@ -43,6 +43,14 @@ private:
   // Consumed by setObjectShape() so UnstableShapeFilter commits the new length correctly.
   BicycleMotionModel::LengthUpdateAnchor shape_update_anchor_;
 
+  // A center-position camera supplies a nominal, fixed vehicle footprint rather
+  // than a newly observed extension on every frame.  Keep that physical length
+  // separate from the bicycle model's two endpoint states: those endpoints can
+  // otherwise drift apart during prediction even though the actual car cannot
+  // grow or shrink.
+  double nominal_length_{0.0};
+  bool lock_nominal_length_{false};
+
   // EKF kinematic update — selects update variant based on data availability.
   bool updateKinematics(
     const types::DynamicObject & object, const types::InputChannel & channel_info);
@@ -84,11 +92,16 @@ public:
   // mergeFootprintFrom() is handled by the base via getShapeModel().mergeFrom().
   void setObjectShape(const autoware_perception_msgs::msg::Shape & shape) override;
 
-  // Clusters (trust_extension=false) have unreliable bbox orientation — always use conditioned.
+  // A source that provides a real object center uses the ordinary center-pose
+  // update even when its dimensions are nominal.  Partial clusters retain the
+  // legacy edge-conditioned path.
   UpdatePath selectUpdatePath(
-    bool trust_extension, bool has_significant_shape_change) const override
+    const types::InputChannel & channel_info, bool has_significant_shape_change) const override
   {
-    if (!trust_extension) return UpdatePath::CONDITIONED;
+    if (channel_info.trust_position_as_center && !channel_info.trust_extension) {
+      return UpdatePath::CENTER_POSITION;
+    }
+    if (!channel_info.trust_extension) return UpdatePath::CONDITIONED;
     return has_significant_shape_change ? UpdatePath::TRY_EXTENSION : UpdatePath::NORMAL;
   }
 };

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/types.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/types.hpp
@@ -241,6 +241,11 @@ struct InputChannel
   struct BirthGuard
   {
     bool enabled = false;
+    // A camera-only race policy for known 1v1 operation.  While a live tracker with the same
+    // semantic label exists, every unmatched measurement remains a birth hypothesis regardless
+    // of bearing.  This prevents a temporally coherent false reprojection from becoming a second
+    // opponent UUID.  Keep false by default so generic multi-object channels are unchanged.
+    bool single_opponent_mode = false;
     int min_confirmations = 3;
     int min_established_measurements = 2;
     double hypothesis_timeout_sec = 0.35;

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/types.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/types.hpp
@@ -36,6 +36,7 @@
 #include <boost/optional.hpp>
 
 #include <array>
+#include <cmath>
 #include <functional>
 #include <optional>
 #include <stdexcept>
@@ -228,7 +229,76 @@ struct InputChannel
   bool trust_classification = true;                        // trust object classification
   bool trust_orientation = true;                           // trust object orientation(yaw)
   AssociationType associator_type = AssociationType::BEV;  // which associator to use
+  // True when pose.position is the full object's geometric center even if the
+  // reported extension is only nominal or otherwise untrusted.  This is
+  // deliberately independent of trust_extension: association/shape handling
+  // may stay conservative while the kinematic filter consumes a valid center.
+  bool trust_position_as_center = false;
+
+  // Opt-in guard for camera-only depth ambiguity.  Birth quarantine and associated-update
+  // innovation checking are independently switchable.  Defaults keep the upstream behavior
+  // unchanged for every channel.
+  struct BirthGuard
+  {
+    bool enabled = false;
+    int min_confirmations = 3;
+    int min_established_measurements = 2;
+    double hypothesis_timeout_sec = 0.35;
+    double hypothesis_match_distance_m = 3.0;
+    double hypothesis_max_speed_mps = 100.0;
+    double conflict_max_coast_age_sec = 0.8;
+    double conflict_min_range_gap_m = 12.0;
+    double conflict_max_bearing_deg = 2.0;
+
+    // An associated monocular-camera measurement can be the alternate intersection of the same
+    // image ray with a farther/nearer part of the track.  Association covariance can legitimately
+    // be broad enough to accept that mode, so this optional second gate limits only the unexplained
+    // radial innovation relative to the tracker's velocity-aware prediction.  The base allowance
+    // is the bounded camera/model-noise budget; deliberately do not grow it from monocular depth
+    // covariance, because that covariance is precisely what cannot distinguish the alternate mode.
+    struct UpdateGuard
+    {
+      bool enabled = false;
+      int min_measurements = 3;
+      double base_allowance_m = 0.75;
+      double max_innovation_speed_mps = 35.0;
+      double max_elapsed_sec = 0.15;
+      double max_allowance_m = 4.5;
+      double max_bearing_deg = 2.0;
+      double max_euclidean_innovation_m = 5.0;
+    } update_guard;
+  } birth_guard;
 };
+
+inline bool isValidBirthGuardConfig(const InputChannel::BirthGuard & config)
+{
+  const bool all_finite =
+    std::isfinite(config.hypothesis_timeout_sec) &&
+    std::isfinite(config.hypothesis_match_distance_m) &&
+    std::isfinite(config.hypothesis_max_speed_mps) &&
+    std::isfinite(config.conflict_max_coast_age_sec) &&
+    std::isfinite(config.conflict_min_range_gap_m) &&
+    std::isfinite(config.conflict_max_bearing_deg) &&
+    std::isfinite(config.update_guard.base_allowance_m) &&
+    std::isfinite(config.update_guard.max_innovation_speed_mps) &&
+    std::isfinite(config.update_guard.max_elapsed_sec) &&
+    std::isfinite(config.update_guard.max_allowance_m) &&
+    std::isfinite(config.update_guard.max_bearing_deg) &&
+    std::isfinite(config.update_guard.max_euclidean_innovation_m);
+  return all_finite && config.min_confirmations >= 1 &&
+         config.min_established_measurements >= 1 && config.hypothesis_timeout_sec > 0.0 &&
+         config.hypothesis_match_distance_m >= 0.0 && config.hypothesis_max_speed_mps >= 0.0 &&
+         config.conflict_max_coast_age_sec > 0.0 && config.conflict_min_range_gap_m > 0.0 &&
+         config.conflict_max_bearing_deg > 0.0 && config.conflict_max_bearing_deg < 180.0 &&
+         config.update_guard.min_measurements >= 3 &&
+         config.update_guard.base_allowance_m >= 0.0 &&
+         config.update_guard.max_innovation_speed_mps >= 0.0 &&
+         config.update_guard.max_elapsed_sec > 0.0 &&
+         config.update_guard.max_allowance_m >= config.update_guard.base_allowance_m &&
+         config.update_guard.max_bearing_deg > 0.0 &&
+         config.update_guard.max_bearing_deg < 180.0 &&
+         config.update_guard.max_euclidean_innovation_m >= config.update_guard.max_allowance_m;
+}
 
 struct ExistenceProbability
 {

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/types.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/types.hpp
@@ -353,6 +353,10 @@ struct DynamicObject
   // object extension (size and shape)
   autoware_perception_msgs::msg::Shape shape;
   bool trust_extension;
+  // Preserve the input-channel center-position contract through conversion,
+  // uncertainty modelling, and frame transformation so a tracker born from a
+  // center-only camera measurement can apply that policy immediately.
+  bool trust_position_as_center{false};
   double area;
 };
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/tracker_base.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/tracker_base.cpp
@@ -58,6 +58,7 @@ Tracker::Tracker(const rclcpp::Time & time, const types::DynamicObject & detecte
   total_no_measurement_count_(0),
   total_measurement_count_(1),
   last_update_with_measurement_time_(time),
+  last_existence_probability_update_time_(time),
   channel_index_(detected_object.channel_index),
   existence_probability_(detected_object.existence_probability),
   kinematics_(detected_object.kinematics),
@@ -143,8 +144,8 @@ bool Tracker::updateWithMeasurement(
     ++total_measurement_count_;
 
     // existence probability on each channel
-    const float delta_time =
-      std::abs((measurement_time - last_update_with_measurement_time_).seconds());
+    const float delta_time = static_cast<float>(
+      std::max(0.0, (measurement_time - last_existence_probability_update_time_).seconds()));
     constexpr float probability_true_detection = 0.9;
     constexpr float probability_false_detection = 0.2;
 
@@ -177,6 +178,13 @@ bool Tracker::updateWithMeasurement(
     total_existence_probability_ = updateProbability(
       total_existence_probability_, object.existence_probability * probability_true_detection,
       probability_false_detection);
+
+    // Existence probabilities may already have been decayed by prediction-only updates since the
+    // last accepted measurement. Advance this independent clock so a later measurement does not
+    // apply the same elapsed interval to the other channels a second time.
+    if (measurement_time > last_existence_probability_update_time_) {
+      last_existence_probability_update_time_ = measurement_time;
+    }
   }
 
   last_update_with_measurement_time_ = measurement_time;
@@ -201,11 +209,17 @@ bool Tracker::updateWithMeasurement(
   }
   setOrientationAvailability(kinematics_.orientation_availability);
 
-  // Select update path: NORMAL / TRY_EXTENSION / CONDITIONED
+  // Select update path: NORMAL / CENTER_POSITION / TRY_EXTENSION / CONDITIONED
   const UpdatePath path =
-    selectUpdatePath(channel_info.trust_extension, has_significant_shape_change);
+    selectUpdatePath(channel_info, has_significant_shape_change);
 
-  if (path == UpdatePath::NORMAL) {
+  if (path == UpdatePath::CENTER_POSITION) {
+    // pose.position is a full-object center, but extension is deliberately
+    // untrusted.  Update the kinematics without allowing this channel to reset
+    // another sensor's shape-filter history or extension-trust state.
+    measure(object, measurement_time, channel_info);
+
+  } else if (path == UpdatePath::NORMAL) {
     unstable_shape_filter_.processNormalMeasurement(object);
     measure(object, measurement_time, channel_info);
     trust_extension_ = object.trust_extension;
@@ -245,11 +259,15 @@ bool Tracker::updateWithoutMeasurement(const rclcpp::Time & timestamp)
   ++total_no_measurement_count_;
   {
     // decay existence probability
-    float const delta_time = (timestamp - last_update_with_measurement_time_).seconds();
+    const float delta_time = static_cast<float>(
+      std::max(0.0, (timestamp - last_existence_probability_update_time_).seconds()));
     for (auto & prob : existence_probabilities_) {
       prob.existence_probability = decayProbability(prob.existence_probability, delta_time);
     }
     total_existence_probability_ = decayProbability(total_existence_probability_, delta_time);
+    if (timestamp > last_existence_probability_update_time_) {
+      last_existence_probability_update_time_ = timestamp;
+    }
   }
 
   return true;

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -97,6 +97,7 @@ VehicleTracker::VehicleTracker(
           object_model_.size_limit.length_max)
       : object_model_.init_size.length;
   nominal_length_ = initial_length;
+  lock_nominal_length_ = object.trust_position_as_center && !object.trust_extension;
 
   // Set motion model parameters
   motion_model_.setMotionParams(
@@ -253,7 +254,7 @@ bool VehicleTracker::measure(
   const types::DynamicObject corrected = normalizeYaw(in_object, motion_model_.getYawState());
 
   const bool is_bbox = (corrected.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
-  updateKinematics(corrected, channel_info);
+  const bool kinematics_updated = updateKinematics(corrected, channel_info);
   if (channel_info.trust_position_as_center && !channel_info.trust_extension) {
     lock_nominal_length_ = true;
     // The dimensions on this channel are nominal metadata, not a per-frame
@@ -264,6 +265,13 @@ bool VehicleTracker::measure(
   }
   if (channel_info.trust_extension && is_bbox) {
     shape_model_.updateShape(corrected);
+    // A trusted normal update is allowed to revise vehicle length.  Once a
+    // center-only camera channel has enabled the prediction-time length lock,
+    // advance its reference to the newly accepted filtered length instead of
+    // restoring a stale pre-camera value on the next predict().
+    if (kinematics_updated) {
+      nominal_length_ = motion_model_.getLength();
+    }
   }
 
   // A footprint is extension data too.  A center-only channel must not mutate

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -96,6 +96,7 @@ VehicleTracker::VehicleTracker(
           object.shape.dimensions.x, object_model_.size_limit.length_min,
           object_model_.size_limit.length_max)
       : object_model_.init_size.length;
+  nominal_length_ = initial_length;
 
   // Set motion model parameters
   motion_model_.setMotionParams(
@@ -145,7 +146,17 @@ VehicleTracker::VehicleTracker(
 
 bool VehicleTracker::predict(const rclcpp::Time & time)
 {
-  return motion_model_.predictState(time);
+  const bool predicted = motion_model_.predictState(time);
+  if (predicted && lock_nominal_length_) {
+    // Prediction evolves the two bicycle endpoints independently.  Restore
+    // their physical separation about the same weighted body center so a
+    // detection gap cannot turn state uncertainty into a 10--20 m car.
+    const bool length_restored = motion_model_.updateStateLength(
+      nominal_length_, BicycleMotionModel::LengthUpdateAnchor::CENTER);
+    removeCache();
+    return length_restored;
+  }
+  return predicted;
 }
 
 bool VehicleTracker::updateKinematics(
@@ -243,18 +254,30 @@ bool VehicleTracker::measure(
 
   const bool is_bbox = (corrected.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
   updateKinematics(corrected, channel_info);
+  if (channel_info.trust_position_as_center && !channel_info.trust_extension) {
+    lock_nominal_length_ = true;
+    // The dimensions on this channel are nominal metadata, not a per-frame
+    // shape observation.  Preserve the constructor/trusted-shape length while
+    // retaining the just-updated center position.
+    motion_model_.updateStateLength(
+      nominal_length_, BicycleMotionModel::LengthUpdateAnchor::CENTER);
+  }
   if (channel_info.trust_extension && is_bbox) {
     shape_model_.updateShape(corrected);
   }
 
-  // Get current tracker pose for footprint transform
-  geometry_msgs::msg::Pose tracker_pose;
-  std::array<double, 36> dummy_cov{};
-  geometry_msgs::msg::Twist dummy_twist;
-  const bool has_pose =
-    motion_model_.getPredictedState(time, tracker_pose, dummy_cov, dummy_twist, dummy_cov);
-  shape_model_.updateFootprint(
-    corrected, time, has_pose ? std::make_optional(tracker_pose) : std::nullopt);
+  // A footprint is extension data too.  A center-only channel must not mutate
+  // stored geometry merely because a future producer happens to populate the
+  // footprint field while declaring its extension untrusted.
+  if (channel_info.trust_extension) {
+    geometry_msgs::msg::Pose tracker_pose;
+    std::array<double, 36> dummy_cov{};
+    geometry_msgs::msg::Twist dummy_twist;
+    const bool has_pose =
+      motion_model_.getPredictedState(time, tracker_pose, dummy_cov, dummy_twist, dummy_cov);
+    shape_model_.updateFootprint(
+      corrected, time, has_pose ? std::make_optional(tracker_pose) : std::nullopt);
+  }
 
   shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::CENTER;
   removeCache();
@@ -360,6 +383,7 @@ void VehicleTracker::setObjectShape(const autoware_perception_msgs::msg::Shape &
 {
   const auto new_len = shape_model_.setShape(shape, getLatestMeasurementTime());
   if (new_len) {
+    nominal_length_ = *new_len;
     motion_model_.updateStateLength(*new_len, shape_update_anchor_);
   }
   shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::CENTER;

--- a/perception/autoware_multi_object_tracker/package.xml
+++ b/perception/autoware_multi_object_tracker/package.xml
@@ -23,6 +23,7 @@
   <depend>eigen</depend>
   <depend>mussp</depend>
   <depend>nav_msgs</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rosbag2_cpp</depend>

--- a/perception/autoware_multi_object_tracker/schema/input_channels.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/input_channels.schema.json
@@ -39,8 +39,112 @@
               "type": "boolean",
               "description": "Indicates if the input channel can trust the object orientation.",
               "default": true
+            },
+            "can_trust_position_as_center": {
+              "type": "boolean",
+              "description": "Indicates that pose.position is the full object's geometric center, independently of extension and orientation trust.",
+              "default": false
             }
           }
+        },
+        "birth_guard": {
+          "type": "object",
+          "description": "Opt-in birth quarantine for a farther, same-bearing camera measurement while an established tracker is coasting. Disabled by default so generic/LiDAR/radar behavior is unchanged. Guard-enabled unmatched births fail closed while ego pose is unavailable, and non-finite measurement XY is rejected. If the nearer car is occluded, a real collinear farther car can be delayed, but only for conflict_max_coast_age_sec or until the old tracker is observed/pruned.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "min_confirmations": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 3
+            },
+            "min_established_measurements": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 2
+            },
+            "hypothesis_timeout_sec": {
+              "type": "number",
+              "exclusiveMinimum": 0.0,
+              "default": 0.35
+            },
+            "hypothesis_match_distance_m": {
+              "type": "number",
+              "minimum": 0.0,
+              "default": 3.0
+            },
+            "hypothesis_max_speed_mps": {
+              "type": "number",
+              "minimum": 0.0,
+              "default": 100.0
+            },
+            "conflict_max_coast_age_sec": {
+              "type": "number",
+              "exclusiveMinimum": 0.0,
+              "default": 0.8
+            },
+            "conflict_min_range_gap_m": {
+              "type": "number",
+              "exclusiveMinimum": 0.0,
+              "default": 12.0
+            },
+            "conflict_max_bearing_deg": {
+              "type": "number",
+              "exclusiveMinimum": 0.0,
+              "exclusiveMaximum": 180.0,
+              "default": 2.0
+            },
+            "update_guard": {
+              "type": "object",
+              "description": "Optional associated-update gate for same-bearing camera depth aliases. For established tracks it compares radial measurement innovation with the velocity-aware tracker prediction. Allowed innovation is min(max_allowance_m, base_allowance_m + max_innovation_speed_mps * min(elapsed time since the last accepted measurement, max_elapsed_sec)). Before min_measurements, only the looser max_euclidean_innovation_m cap applies so real vehicle motion can bootstrap velocity. That Euclidean cap also prevents an arbitrarily large jump just outside max_bearing_deg. Monocular depth covariance is intentionally not an escape hatch because it cannot distinguish the alternate ray/mesh mode. A rejected association is consumed for that cycle, the tracker coasts, and no new UUID is spawned. A real second car exactly behind an associated track can therefore be delayed until association separates or the old track expires.",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "min_measurements": {
+                  "type": "integer",
+                  "minimum": 3,
+                  "default": 3
+                },
+                "base_allowance_m": {
+                  "type": "number",
+                  "minimum": 0.0,
+                  "default": 0.75
+                },
+                "max_innovation_speed_mps": {
+                  "type": "number",
+                  "minimum": 0.0,
+                  "default": 35.0
+                },
+                "max_elapsed_sec": {
+                  "type": "number",
+                  "exclusiveMinimum": 0.0,
+                  "default": 0.15
+                },
+                "max_allowance_m": {
+                  "type": "number",
+                  "minimum": 0.0,
+                  "default": 4.5
+                },
+                "max_bearing_deg": {
+                  "type": "number",
+                  "exclusiveMinimum": 0.0,
+                  "exclusiveMaximum": 180.0,
+                  "default": 2.0
+                },
+                "max_euclidean_innovation_m": {
+                  "type": "number",
+                  "minimum": 0.0,
+                  "default": 5.0
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         },
         "optional": {
           "type": "object",

--- a/perception/autoware_multi_object_tracker/schema/input_channels.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/input_channels.schema.json
@@ -55,6 +55,11 @@
               "type": "boolean",
               "default": false
             },
+            "single_opponent_mode": {
+              "type": "boolean",
+              "description": "When enabled for a known 1v1 camera channel, unmatched measurements with the same semantic label remain birth hypotheses while a live tracker exists.",
+              "default": false
+            },
             "min_confirmations": {
               "type": "integer",
               "minimum": 1,

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -134,6 +134,13 @@
           "description": "Timer frequency to output with delay compensation.",
           "default": 10.0
         },
+        "detection_subscription_depth": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "description": "KEEP_LAST history depth for each detected-object subscription.",
+          "default": 1
+        },
         "world_frame_id": {
           "type": "string",
           "description": "Object kinematics definition frame.",

--- a/perception/autoware_multi_object_tracker/src/detection_subscription_qos.hpp
+++ b/perception/autoware_multi_object_tracker/src/detection_subscription_qos.hpp
@@ -1,0 +1,50 @@
+// Copyright 2020 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DETECTION_SUBSCRIPTION_QOS_HPP_
+#define DETECTION_SUBSCRIPTION_QOS_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+
+namespace autoware::multi_object_tracker::input_qos
+{
+
+constexpr int kDepthMin = 1;
+constexpr int kDepthMax = 1000;
+constexpr int kDepthDefault = 1;
+
+inline bool isValidDepth(const int requested)
+{
+  return requested >= kDepthMin && requested <= kDepthMax;
+}
+
+inline int requireValidDepth(const int requested)
+{
+  if (!isValidDepth(requested)) {
+    throw std::invalid_argument("detection subscription depth is outside the supported range");
+  }
+  return requested;
+}
+
+inline rclcpp::QoS detectionQos(const int depth)
+{
+  return rclcpp::QoS{static_cast<size_t>(requireValidDepth(depth))};
+}
+
+}  // namespace autoware::multi_object_tracker::input_qos
+
+#endif  // DETECTION_SUBSCRIPTION_QOS_HPP_

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -16,8 +16,13 @@
 
 #include "multi_object_tracker_node.hpp"
 
+#include "detection_subscription_qos.hpp"
+
 #include "autoware/multi_object_tracker/types.hpp"
 #include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"
+
+#include <rcl_interfaces/msg/integer_range.hpp>
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
 
 #include <algorithm>
 #include <array>
@@ -48,6 +53,18 @@ TrackerType parseTrackerType(const std::string & name, const std::string & param
       "'. Strict string match is required.");
   }
   return *tracker_type;
+}
+
+int validatedDetectionSubscriptionDepth(const int requested, const rclcpp::Logger & logger)
+{
+  if (!input_qos::isValidDepth(requested)) {
+    const std::string message =
+      "detection_subscription_depth " + std::to_string(requested) + " is outside [" +
+      std::to_string(input_qos::kDepthMin) + ", " + std::to_string(input_qos::kDepthMax) + "]";
+    RCLCPP_ERROR(logger, "%s", message.c_str());
+    throw std::invalid_argument(message);
+  }
+  return requested;
 }
 }  // namespace
 
@@ -95,6 +112,7 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
         input_channel_config.trust_extension = false;
         input_channel_config.trust_classification = false;
         input_channel_config.trust_orientation = false;
+        input_channel_config.trust_position_as_center = false;
         input_channel_config.long_name = "none";
         input_channel_config.short_name = "none";
         params_.input_channels_config.push_back(input_channel_config);
@@ -123,6 +141,68 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
       // trust object orientation(yaw)
       input_channel_config.trust_orientation =
         declare_parameter<bool>(input_channel_config_name + ".flags.can_trust_orientation", true);
+
+      // Whether pose.position is a trustworthy full-object center.  Keep this
+      // separate from extension trust: a detector may emit a well-defined
+      // center with nominal dimensions and no measured yaw.
+      input_channel_config.trust_position_as_center = declare_parameter<bool>(
+        input_channel_config_name + ".flags.can_trust_position_as_center", false);
+
+      // Camera depth ambiguity birth guard.  This is opt-in per channel; keeping `enabled` absent
+      // or false preserves the shipped spawn behavior for generic, LiDAR, and radar inputs.
+      auto & birth_guard = input_channel_config.birth_guard;
+      const std::string birth_guard_name = input_channel_config_name + ".birth_guard.";
+      birth_guard.enabled =
+        declare_parameter<bool>(birth_guard_name + "enabled", birth_guard.enabled);
+      birth_guard.min_confirmations = declare_parameter<int>(
+        birth_guard_name + "min_confirmations", birth_guard.min_confirmations);
+      birth_guard.min_established_measurements = declare_parameter<int>(
+        birth_guard_name + "min_established_measurements",
+        birth_guard.min_established_measurements);
+      birth_guard.hypothesis_timeout_sec = declare_parameter<double>(
+        birth_guard_name + "hypothesis_timeout_sec", birth_guard.hypothesis_timeout_sec);
+      birth_guard.hypothesis_match_distance_m = declare_parameter<double>(
+        birth_guard_name + "hypothesis_match_distance_m",
+        birth_guard.hypothesis_match_distance_m);
+      birth_guard.hypothesis_max_speed_mps = declare_parameter<double>(
+        birth_guard_name + "hypothesis_max_speed_mps", birth_guard.hypothesis_max_speed_mps);
+      birth_guard.conflict_max_coast_age_sec = declare_parameter<double>(
+        birth_guard_name + "conflict_max_coast_age_sec",
+        birth_guard.conflict_max_coast_age_sec);
+      birth_guard.conflict_min_range_gap_m = declare_parameter<double>(
+        birth_guard_name + "conflict_min_range_gap_m", birth_guard.conflict_min_range_gap_m);
+      birth_guard.conflict_max_bearing_deg = declare_parameter<double>(
+        birth_guard_name + "conflict_max_bearing_deg", birth_guard.conflict_max_bearing_deg);
+
+      auto & update_guard = birth_guard.update_guard;
+      const std::string update_guard_name = birth_guard_name + "update_guard.";
+      update_guard.enabled =
+        declare_parameter<bool>(update_guard_name + "enabled", update_guard.enabled);
+      update_guard.min_measurements = declare_parameter<int>(
+        update_guard_name + "min_measurements", update_guard.min_measurements);
+      update_guard.base_allowance_m = declare_parameter<double>(
+        update_guard_name + "base_allowance_m", update_guard.base_allowance_m);
+      update_guard.max_innovation_speed_mps = declare_parameter<double>(
+        update_guard_name + "max_innovation_speed_mps", update_guard.max_innovation_speed_mps);
+      update_guard.max_elapsed_sec = declare_parameter<double>(
+        update_guard_name + "max_elapsed_sec", update_guard.max_elapsed_sec);
+      update_guard.max_allowance_m = declare_parameter<double>(
+        update_guard_name + "max_allowance_m", update_guard.max_allowance_m);
+      update_guard.max_bearing_deg = declare_parameter<double>(
+        update_guard_name + "max_bearing_deg", update_guard.max_bearing_deg);
+      update_guard.max_euclidean_innovation_m = declare_parameter<double>(
+        update_guard_name + "max_euclidean_innovation_m",
+        update_guard.max_euclidean_innovation_m);
+
+      if (!types::isValidBirthGuardConfig(birth_guard)) {
+        throw std::invalid_argument(
+          birth_guard_name +
+          " has invalid values: every floating-point value must be finite, birth counts must be "
+          ">= 1, update min_measurements must be >= 3, distances/speeds must be non-negative, "
+          "timeouts/range gap must be positive, and "
+          "bearings must be in (0, 180) degrees; update allowances must satisfy "
+          "base <= max <= max_euclidean");
+      }
 
       // association algorithm selection for this channel (default: "bev")
       {
@@ -258,6 +338,21 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
 
   ////// Create subscriptions and publishers
   // subscriptions
+  rcl_interfaces::msg::ParameterDescriptor depth_descriptor;
+  depth_descriptor.description =
+    "KEEP_LAST history depth for each detected-object subscription";
+  rcl_interfaces::msg::IntegerRange depth_range;
+  depth_range.from_value = input_qos::kDepthMin;
+  depth_range.to_value = input_qos::kDepthMax;
+  depth_range.step = 1;
+  depth_descriptor.integer_range.push_back(depth_range);
+  const int detection_subscription_depth = validatedDetectionSubscriptionDepth(
+    declare_parameter<int>(
+      "detection_subscription_depth", input_qos::kDepthDefault, depth_descriptor),
+    get_logger());
+  RCLCPP_INFO(
+    get_logger(), "detection subscription KEEP_LAST depth = %d", detection_subscription_depth);
+
   sub_objects_array_.resize(params_.input_channels_config.size());
   for (const auto & input_channel : params_.input_channels_config) {
     if (!input_channel.is_enabled) {
@@ -271,7 +366,7 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
 
     sub_objects_array_.at(index) =
       create_subscription<autoware_perception_msgs::msg::DetectedObjects>(
-        input_channel_topic, rclcpp::QoS{1},
+        input_channel_topic, input_qos::detectionQos(detection_subscription_depth),
         [this,
          index](AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects)
                   msg) { this->onMeasurement(index, std::move(msg)); });

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -154,6 +154,8 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
       const std::string birth_guard_name = input_channel_config_name + ".birth_guard.";
       birth_guard.enabled =
         declare_parameter<bool>(birth_guard_name + "enabled", birth_guard.enabled);
+      birth_guard.single_opponent_mode = declare_parameter<bool>(
+        birth_guard_name + "single_opponent_mode", birth_guard.single_opponent_mode);
       birth_guard.min_confirmations = declare_parameter<int>(
         birth_guard_name + "min_confirmations", birth_guard.min_confirmations);
       birth_guard.min_established_measurements = declare_parameter<int>(

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -74,9 +74,12 @@ std::optional<types::DynamicObjectList> InputStream::processMessage(
 
   types::DynamicObjectList dynamic_objects = types::toDynamicObjectList(objects, channel_.index);
 
-  // Set trust_extension information from channel configuration
+  // Preserve the channel's geometry contract on each converted object.  The
+  // tracker constructor receives the object before any later measurement call,
+  // so birth-time policy cannot be reconstructed from trust_extension alone.
   for (auto & object : dynamic_objects.objects) {
     object.trust_extension = channel_.trust_extension;
+    object.trust_position_as_center = channel_.trust_position_as_center;
   }
 
   // Model the object uncertainty only if it is not available

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -211,10 +211,11 @@ void InputStream::getObjectsOlderThan(
     }
   }
 
-  // remove objects older than 'object_latest_time'
+  // Remove every object exported above, including one exactly on the inclusive cutoff.  Keeping
+  // the boundary item would make the next callback process the same measurement a second time.
   while (!objects_que_.empty()) {
     const rclcpp::Time object_time = objects_que_.front().getTimestamp();
-    if (object_time < object_latest_time) {
+    if (object_time <= object_latest_time) {
       objects_que_.pop_front();
     } else {
       break;

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -25,9 +25,11 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -115,6 +117,31 @@ void TrackerProcessor::update(const types::AssociatedObjects & associated_object
     if (found) {
       const auto & associated_object = detected_objects.objects.at(measurement_idx);
       const types::InputChannel channel_info = channels_config_[associated_object.channel_index];
+      const auto update_guard_result = evaluateAssociatedUpdate(
+        *tracker_itr, associated_object, time, channel_info.birth_guard.update_guard);
+      if (update_guard_result.reject) {
+        // Keep the association intact: spawn() will see measurement_to_tracker and cannot create a
+        // second UUID from the rejected alternate depth mode in this cycle.  Only the normal
+        // bounded no-measurement path is applied to the established tracker.
+        (*tracker_itr)->updateWithoutMeasurement(time);
+        ++update_guard_rejected_count_;
+        if (update_guard_result.used_no_ego_fallback) {
+          ++update_guard_no_ego_rejected_count_;
+        }
+        if (update_guard_result.invalid_input) {
+          ++update_guard_invalid_rejected_count_;
+        }
+        logBirthGuardStats("associated_update_rejected", associated_object.channel_index);
+        RCLCPP_WARN_THROTTLE(
+          logger_, *clock_, 1000,
+          "Withheld associated camera update on channel %u for tracker %s: radial/XY "
+          "innovation=%.2f m allowance=%.2f m bearing_delta=%.2f deg; tracker is coasting and "
+          "the consumed measurement cannot spawn a new UUID in this cycle",
+          associated_object.channel_index, (*tracker_itr)->getUuidString().c_str(),
+          update_guard_result.innovation_m, update_guard_result.allowance_m,
+          update_guard_result.bearing_difference_deg);
+        continue;
+      }
       const bool has_significant_shape_change = association_result.wasShapeChanged(tracker_uuid);
       (*tracker_itr)
         ->setEgoPose(ego_pose_ ? std::make_optional(ego_pose_->pose.position) : std::nullopt);
@@ -125,6 +152,124 @@ void TrackerProcessor::update(const types::AssociatedObjects & associated_object
       (*(tracker_itr))->updateWithoutMeasurement(time);
     }
   }
+}
+
+TrackerProcessor::UpdateGuardResult TrackerProcessor::evaluateAssociatedUpdate(
+  const std::shared_ptr<Tracker> & tracker, const types::DynamicObject & measurement,
+  const rclcpp::Time & time, const types::InputChannel::BirthGuard::UpdateGuard & config) const
+{
+  UpdateGuardResult result;
+  if (!config.enabled) {
+    return result;
+  }
+
+  types::DynamicObject prediction;
+  if (!tracker->getTrackedObject(time, prediction, false)) {
+    result.reject = true;
+    result.invalid_input = true;
+    return result;
+  }
+
+  const auto finite_xy = [](const geometry_msgs::msg::Point & point) {
+    return std::isfinite(point.x) && std::isfinite(point.y);
+  };
+  if (!finite_xy(measurement.pose.position) || !finite_xy(prediction.pose.position)) {
+    result.reject = true;
+    result.invalid_input = true;
+    return result;
+  }
+
+  const double elapsed_sec = tracker->getElapsedTimeFromLastUpdate(time);
+  if (elapsed_sec < 0.0 || !std::isfinite(elapsed_sec)) {
+    result.reject = true;
+    result.invalid_input = true;
+    return result;
+  }
+  const double bounded_elapsed_sec = std::min(elapsed_sec, config.max_elapsed_sec);
+  result.allowance_m = std::min(
+    config.max_allowance_m,
+    config.base_allowance_m + config.max_innovation_speed_mps * bounded_elapsed_sec);
+  if (!std::isfinite(result.allowance_m)) {
+    result.reject = true;
+    result.invalid_input = true;
+    return result;
+  }
+
+  const double dx = measurement.pose.position.x - prediction.pose.position.x;
+  const double dy = measurement.pose.position.y - prediction.pose.position.y;
+  const double euclidean_innovation = std::hypot(dx, dy);
+  if (!std::isfinite(euclidean_innovation)) {
+    result.reject = true;
+    result.invalid_input = true;
+    return result;
+  }
+  const bool has_usable_ego_pose = ego_pose_ && finite_xy(ego_pose_->pose.position);
+
+  // Velocity needs multiple accepted measurements to bootstrap.  Before that point, do not apply
+  // the tighter velocity-relative radial gate, but still reject a mode switch beyond a loose hard
+  // displacement cap.  The same cap closes the discontinuity just outside max_bearing_deg.
+  if (euclidean_innovation > config.max_euclidean_innovation_m) {
+    result.used_no_ego_fallback = !has_usable_ego_pose;
+    result.innovation_m = euclidean_innovation;
+    result.allowance_m = config.max_euclidean_innovation_m;
+    result.reject = true;
+    return result;
+  }
+  if (tracker->getTotalMeasurementCount() < config.min_measurements) {
+    return result;
+  }
+
+  if (!has_usable_ego_pose) {
+    // Fail closed on a physically impossible associated displacement when odometry/TF is absent.
+    // The fallback is intentionally the looser Euclidean cap because bearing/range cannot be
+    // established safely; the tighter radial allowance has no valid geometry here.
+    result.used_no_ego_fallback = true;
+    result.innovation_m = euclidean_innovation;
+    result.allowance_m = config.max_euclidean_innovation_m;
+    result.reject = result.innovation_m > config.max_euclidean_innovation_m;
+    return result;
+  }
+
+  const auto & ego = ego_pose_->pose.position;
+  const double tracker_x = prediction.pose.position.x - ego.x;
+  const double tracker_y = prediction.pose.position.y - ego.y;
+  const double measurement_x = measurement.pose.position.x - ego.x;
+  const double measurement_y = measurement.pose.position.y - ego.y;
+  const double tracker_range = std::hypot(tracker_x, tracker_y);
+  const double measurement_range = std::hypot(measurement_x, measurement_y);
+  if (
+    !std::isfinite(tracker_range) || !std::isfinite(measurement_range) || tracker_range <= 1e-6 ||
+    measurement_range <= 1e-6) {
+    // Degenerate ego-relative geometry still gets the bounded Euclidean check instead of silently
+    // failing open.
+    result.used_no_ego_fallback = true;
+    result.innovation_m = euclidean_innovation;
+    result.allowance_m = config.max_euclidean_innovation_m;
+    result.reject = result.innovation_m > config.max_euclidean_innovation_m;
+    return result;
+  }
+
+  const double cross = tracker_x * measurement_y - tracker_y * measurement_x;
+  const double dot = tracker_x * measurement_x + tracker_y * measurement_y;
+  const double bearing_difference = std::abs(std::atan2(cross, dot));
+  constexpr double radians_to_degrees = 180.0 / 3.14159265358979323846;
+  result.bearing_difference_deg = bearing_difference * radians_to_degrees;
+  if (!std::isfinite(result.bearing_difference_deg)) {
+    result.reject = true;
+    result.invalid_input = true;
+    return result;
+  }
+  if (result.bearing_difference_deg > config.max_bearing_deg) {
+    return result;
+  }
+
+  // The prediction already contains the tracker's estimated velocity and process covariance.
+  // Association remains the statistical covariance gate.  This extra camera-only check is a
+  // physical bound on unexplained radial motion; allowing raw monocular depth covariance here
+  // would make alternate ray/mesh modes fail open again.
+  result.innovation_m = std::abs(measurement_range - tracker_range);
+  result.reject = result.innovation_m > result.allowance_m;
+  return result;
 }
 
 void TrackerProcessor::spawn(const types::AssociatedObjects & associated_objects)
@@ -141,24 +286,220 @@ void TrackerProcessor::spawn(const types::AssociatedObjects & associated_objects
   }
 
   const auto & time = detected_objects.header.stamp;
+  if (channel_config.birth_guard.enabled) {
+    pruneBirthHypotheses(time, detected_objects.channel_index, channel_config.birth_guard);
+  }
+
   for (size_t i = 0; i < detected_objects.objects.size(); ++i) {
     const auto & new_object = detected_objects.objects.at(i);
     if (association_result.measurement_to_tracker.count(new_object.uuid)) {
       continue;
     }
-    std::shared_ptr<Tracker> tracker = createNewTracker(new_object, time);
-    if (!tracker) continue;  // null combo: (shape, label) not accepted
 
-    if (channel_config.trust_existence_probability) {
-      tracker->initializeExistenceProbabilities(
-        new_object.channel_index, new_object.existence_probability);
-    } else {
-      tracker->initializeExistenceProbabilities(
-        new_object.channel_index, types::default_existence_probability);
+    if (!channel_config.birth_guard.enabled) {
+      addTracker(new_object, time, channel_config);
+      continue;
     }
 
-    list_tracker_.push_back(tracker);
+    if (!std::isfinite(new_object.pose.position.x) ||
+        !std::isfinite(new_object.pose.position.y)) {
+      ++birth_guard_nonfinite_rejected_count_;
+      logBirthGuardStats("rejected_nonfinite_measurement", new_object.channel_index);
+      continue;
+    }
+
+    const bool has_usable_ego_pose =
+      ego_pose_ && std::isfinite(ego_pose_->pose.position.x) &&
+      std::isfinite(ego_pose_->pose.position.y);
+    if (!has_usable_ego_pose) {
+      // Association already decided that this measurement cannot update an existing tracker.  If
+      // ego pose is missing, a range/bearing conflict cannot be ruled out, so fail closed only for
+      // tracker birth. Existing trackers still follow their normal bounded prediction/coast path.
+      ++birth_guard_no_ego_withheld_count_;
+      logBirthGuardStats("withheld_no_ego", new_object.channel_index);
+    }
+    const bool has_conflict =
+      !has_usable_ego_pose ||
+      conflictsWithCoastingTracker(new_object, time, channel_config.birth_guard);
+    auto hypothesis = findBirthHypothesis(new_object, time, channel_config.birth_guard);
+
+    if (hypothesis == birth_hypotheses_.end()) {
+      if (!has_conflict) {
+        // The guard is intentionally not a global camera birth delay.  A non-conflicting object
+        // keeps the normal spawn behavior, including a genuine second car seen beside a tracker
+        // that was successfully updated in this frame.
+        addTracker(new_object, time, channel_config);
+        continue;
+      }
+
+      birth_hypotheses_.push_back(BirthHypothesis{
+        new_object.channel_index, classes::getHighestProbLabel(new_object.classification),
+        new_object.pose.position, time, 1});
+      ++birth_guard_quarantined_count_;
+      logBirthGuardStats("quarantined", new_object.channel_index);
+      RCLCPP_DEBUG(
+        logger_,
+        "Quarantined unmatched %s birth at (%.2f, %.2f): farther same-bearing measurement "
+        "conflicts with a coasting established tracker",
+        classes::toString(classes::getHighestProbLabel(new_object.classification)).c_str(),
+        new_object.pose.position.x, new_object.pose.position.y);
+      continue;
+    }
+
+    hypothesis->position = new_object.pose.position;
+    hypothesis->last_observation_time = time;
+    ++hypothesis->confirmation_count;
+
+    // Confirmation alone must never override an active depth conflict.  It only permits birth
+    // once the old tracker was observed again (so this can be a real second object) or its bounded
+    // coast ended and the tracker was pruned.
+    if (
+      has_conflict ||
+      hypothesis->confirmation_count < channel_config.birth_guard.min_confirmations)
+    {
+      continue;
+    }
+
+    birth_hypotheses_.erase(hypothesis);
+    ++birth_guard_released_count_;
+    logBirthGuardStats("released", new_object.channel_index);
+    addTracker(new_object, time, channel_config);
   }
+}
+
+void TrackerProcessor::addTracker(
+  const types::DynamicObject & object, const rclcpp::Time & time,
+  const types::InputChannel & channel_config)
+{
+  std::shared_ptr<Tracker> tracker = createNewTracker(object, time);
+  if (!tracker) return;  // null combo: (shape, label) not accepted
+
+  const float initial_existence_probability = channel_config.trust_existence_probability
+                                                ? object.existence_probability
+                                                : types::default_existence_probability;
+  tracker->initializeExistenceProbabilities(
+    object.channel_index, initial_existence_probability);
+  list_tracker_.push_back(tracker);
+}
+
+void TrackerProcessor::pruneBirthHypotheses(
+  const rclcpp::Time & time, const uint channel_index,
+  const types::InputChannel::BirthGuard & config)
+{
+  const size_t size_before = birth_hypotheses_.size();
+  birth_hypotheses_.remove_if([&](const BirthHypothesis & hypothesis) {
+    if (hypothesis.channel_index != channel_index) return false;
+    const double age = (time - hypothesis.last_observation_time).seconds();
+    return age < 0.0 || age > config.hypothesis_timeout_sec;
+  });
+  const size_t expired_count = size_before - birth_hypotheses_.size();
+  if (expired_count > 0) {
+    birth_guard_expired_count_ += expired_count;
+    logBirthGuardStats("expired", channel_index);
+  }
+}
+
+std::list<TrackerProcessor::BirthHypothesis>::iterator TrackerProcessor::findBirthHypothesis(
+  const types::DynamicObject & object, const rclcpp::Time & time,
+  const types::InputChannel::BirthGuard & config)
+{
+  const auto label = classes::getHighestProbLabel(object.classification);
+  auto nearest = birth_hypotheses_.end();
+  double nearest_distance_sq = std::numeric_limits<double>::infinity();
+
+  for (auto it = birth_hypotheses_.begin(); it != birth_hypotheses_.end(); ++it) {
+    if (it->channel_index != object.channel_index || it->label != label) continue;
+
+    const double dt = (time - it->last_observation_time).seconds();
+    // dt == 0 also prevents two objects in one message from consuming one hypothesis.
+    if (dt <= 0.0 || dt > config.hypothesis_timeout_sec) continue;
+
+    const double dx = object.pose.position.x - it->position.x;
+    const double dy = object.pose.position.y - it->position.y;
+    const double distance_sq = dx * dx + dy * dy;
+    const double max_distance =
+      config.hypothesis_match_distance_m + config.hypothesis_max_speed_mps * dt;
+    if (distance_sq <= max_distance * max_distance && distance_sq < nearest_distance_sq) {
+      nearest = it;
+      nearest_distance_sq = distance_sq;
+    }
+  }
+  return nearest;
+}
+
+bool TrackerProcessor::conflictsWithCoastingTracker(
+  const types::DynamicObject & object, const rclcpp::Time & time,
+  const types::InputChannel::BirthGuard & config) const
+{
+  if (
+    !ego_pose_ || !std::isfinite(ego_pose_->pose.position.x) ||
+    !std::isfinite(ego_pose_->pose.position.y)) {
+    return true;
+  }
+
+  const auto measurement_label = classes::getHighestProbLabel(object.classification);
+  const auto & ego = ego_pose_->pose.position;
+  const double measurement_x = object.pose.position.x - ego.x;
+  const double measurement_y = object.pose.position.y - ego.y;
+  const double measurement_range = std::hypot(measurement_x, measurement_y);
+  if (measurement_range <= config.conflict_min_range_gap_m) return false;
+
+  constexpr double degrees_to_radians = 3.14159265358979323846 / 180.0;
+  const double max_bearing = config.conflict_max_bearing_deg * degrees_to_radians;
+
+  for (const auto & tracker : list_tracker_) {
+    if (
+      tracker->getTotalMeasurementCount() < config.min_established_measurements ||
+      tracker->getNoMeasurementCount() == 0 ||
+      tracker->getHighestProbLabel() != measurement_label)
+    {
+      continue;
+    }
+
+    const double coast_age = tracker->getElapsedTimeFromLastUpdate(time);
+    if (coast_age < 0.0 || coast_age > config.conflict_max_coast_age_sec) continue;
+
+    // Publish confidence is deliberately not a birth-conflict prerequisite.  Rejected alternate-
+    // depth updates make an established tracker coast, which can lower its existence probability
+    // or grow its covariance below the publish threshold before this bounded coast window ends.
+    // Letting that temporary output state bypass the guard immediately creates a second UUID from
+    // the same monocular target.  Expired trackers have already been removed by prune(), while the
+    // measurement-count, coast-age, label, range, and bearing checks below bound this quarantine.
+
+    types::DynamicObject prediction;
+    if (!tracker->getTrackedObject(time, prediction, false)) continue;
+
+    const double tracker_x = prediction.pose.position.x - ego.x;
+    const double tracker_y = prediction.pose.position.y - ego.y;
+    const double tracker_range = std::hypot(tracker_x, tracker_y);
+    if (tracker_range <= 1e-6) continue;
+
+    const double range_gap = measurement_range - tracker_range;
+    if (range_gap < config.conflict_min_range_gap_m) continue;
+
+    const double cross = tracker_x * measurement_y - tracker_y * measurement_x;
+    const double dot = tracker_x * measurement_x + tracker_y * measurement_y;
+    const double bearing_difference = std::abs(std::atan2(cross, dot));
+    if (bearing_difference <= max_bearing) return true;
+  }
+  return false;
+}
+
+void TrackerProcessor::logBirthGuardStats(const char * event, const uint channel_index) const
+{
+  RCLCPP_INFO_THROTTLE(
+    logger_, *clock_, 1000,
+    "Birth guard %s on channel %u: quarantined=%llu released=%llu expired=%llu "
+    "no_ego_withheld=%llu nonfinite_rejected=%llu active=%zu update_rejected=%llu "
+    "update_no_ego_rejected=%llu update_invalid_rejected=%llu",
+    event, channel_index, static_cast<unsigned long long>(birth_guard_quarantined_count_),
+    static_cast<unsigned long long>(birth_guard_released_count_),
+    static_cast<unsigned long long>(birth_guard_expired_count_),
+    static_cast<unsigned long long>(birth_guard_no_ego_withheld_count_),
+    static_cast<unsigned long long>(birth_guard_nonfinite_rejected_count_),
+    birth_hypotheses_.size(), static_cast<unsigned long long>(update_guard_rejected_count_),
+    static_cast<unsigned long long>(update_guard_no_ego_rejected_count_),
+    static_cast<unsigned long long>(update_guard_invalid_rejected_count_));
 }
 
 std::shared_ptr<Tracker> TrackerProcessor::createNewTracker(

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -318,8 +318,16 @@ void TrackerProcessor::spawn(const types::AssociatedObjects & associated_objects
       ++birth_guard_no_ego_withheld_count_;
       logBirthGuardStats("withheld_no_ego", new_object.channel_index);
     }
+    const auto measurement_label = classes::getHighestProbLabel(new_object.classification);
+    const bool conflicts_with_live_opponent =
+      channel_config.birth_guard.single_opponent_mode &&
+      std::any_of(
+        list_tracker_.cbegin(), list_tracker_.cend(),
+        [measurement_label](const auto & tracker) {
+          return tracker->getHighestProbLabel() == measurement_label;
+        });
     const bool has_conflict =
-      !has_usable_ego_pose ||
+      !has_usable_ego_pose || conflicts_with_live_opponent ||
       conflictsWithCoastingTracker(new_object, time, channel_config.birth_guard);
     auto hypothesis = findBirthHypothesis(new_object, time, channel_config.birth_guard);
 
@@ -339,8 +347,8 @@ void TrackerProcessor::spawn(const types::AssociatedObjects & associated_objects
       logBirthGuardStats("quarantined", new_object.channel_index);
       RCLCPP_DEBUG(
         logger_,
-        "Quarantined unmatched %s birth at (%.2f, %.2f): farther same-bearing measurement "
-        "conflicts with a coasting established tracker",
+        "Quarantined unmatched %s birth at (%.2f, %.2f): measurement conflicts with the "
+        "configured camera birth policy",
         classes::toString(classes::getHighestProbLabel(new_object.classification)).c_str(),
         new_object.pose.position.x, new_object.pose.position.y);
       continue;

--- a/perception/autoware_multi_object_tracker/src/processor/processor.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.hpp
@@ -28,6 +28,7 @@
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <optional>
@@ -70,6 +71,25 @@ public:
   void setTimeKeeper(std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_ptr);
 
 private:
+  struct BirthHypothesis
+  {
+    uint channel_index;
+    classes::Label label;
+    geometry_msgs::msg::Point position;
+    rclcpp::Time last_observation_time;
+    int confirmation_count;
+  };
+
+  struct UpdateGuardResult
+  {
+    bool reject{false};
+    bool used_no_ego_fallback{false};
+    bool invalid_input{false};
+    double innovation_m{0.0};
+    double allowance_m{0.0};
+    double bearing_difference_deg{-1.0};
+  };
+
   const TrackerConfigs tracker_configs_;
   const TrackerCreationConfig creation_config_;
   const std::vector<types::InputChannel> & channels_config_;
@@ -82,10 +102,35 @@ private:
   mutable rclcpp::Time last_prune_time_;
 
   std::list<std::shared_ptr<Tracker>> list_tracker_;
+  std::list<BirthHypothesis> birth_hypotheses_;
+  uint64_t birth_guard_quarantined_count_{0};
+  uint64_t birth_guard_released_count_{0};
+  uint64_t birth_guard_expired_count_{0};
+  uint64_t birth_guard_no_ego_withheld_count_{0};
+  uint64_t birth_guard_nonfinite_rejected_count_{0};
+  uint64_t update_guard_rejected_count_{0};
+  uint64_t update_guard_no_ego_rejected_count_{0};
+  uint64_t update_guard_invalid_rejected_count_{0};
   std::optional<geometry_msgs::msg::Pose> getEgoPose() const;
   void removeOldTracker(const rclcpp::Time & time);
   std::shared_ptr<Tracker> createNewTracker(
     const types::DynamicObject & object, const rclcpp::Time & time) const;
+  void addTracker(
+    const types::DynamicObject & object, const rclcpp::Time & time,
+    const types::InputChannel & channel_config);
+  void pruneBirthHypotheses(
+    const rclcpp::Time & time, uint channel_index,
+    const types::InputChannel::BirthGuard & config);
+  std::list<BirthHypothesis>::iterator findBirthHypothesis(
+    const types::DynamicObject & object, const rclcpp::Time & time,
+    const types::InputChannel::BirthGuard & config);
+  bool conflictsWithCoastingTracker(
+    const types::DynamicObject & object, const rclcpp::Time & time,
+    const types::InputChannel::BirthGuard & config) const;
+  UpdateGuardResult evaluateAssociatedUpdate(
+    const std::shared_ptr<Tracker> & tracker, const types::DynamicObject & measurement,
+    const rclcpp::Time & time, const types::InputChannel::BirthGuard::UpdateGuard & config) const;
+  void logBirthGuardStats(const char * event, uint channel_index) const;
 
   std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
   AdaptiveThresholdCache adaptive_threshold_cache_;

--- a/perception/autoware_multi_object_tracker/test/test_birth_guard.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_birth_guard.cpp
@@ -1,0 +1,533 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/processor/processor.hpp"
+#include "test_bench.hpp"
+#include "test_utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+
+namespace mot = autoware::multi_object_tracker;
+using std::chrono_literals::operator""ms;
+
+class BirthGuardTest : public ::testing::Test
+{
+protected:
+  using Processor = mot::TrackerProcessor;
+
+  void SetUp() override
+  {
+    tracker_configs_ = createTrackerConfigs();
+    creation_config_ = createTrackerCreationConfig();
+    association_config_ = createTrackerAssociationConfig();
+    overlap_config_ = createTrackerOverlapManagerConfig();
+    channels_ = createInputChannelsConfig();
+    channels_.front().trust_position_as_center = true;
+    channels_.front().birth_guard.enabled = true;
+    channels_.front().birth_guard.min_confirmations = 3;
+    channels_.front().birth_guard.min_established_measurements = 2;
+    channels_.front().birth_guard.hypothesis_timeout_sec = 0.35;
+    channels_.front().birth_guard.hypothesis_match_distance_m = 1.0;
+    channels_.front().birth_guard.hypothesis_max_speed_mps = 100.0;
+    channels_.front().birth_guard.conflict_max_coast_age_sec = 0.8;
+    channels_.front().birth_guard.conflict_min_range_gap_m = 12.0;
+    channels_.front().birth_guard.conflict_max_bearing_deg = 2.0;
+    channels_.front().birth_guard.update_guard.enabled = true;
+    channels_.front().birth_guard.update_guard.min_measurements = 3;
+    channels_.front().birth_guard.update_guard.base_allowance_m = 0.75;
+    channels_.front().birth_guard.update_guard.max_innovation_speed_mps = 35.0;
+    channels_.front().birth_guard.update_guard.max_elapsed_sec = 0.15;
+    channels_.front().birth_guard.update_guard.max_allowance_m = 4.5;
+    channels_.front().birth_guard.update_guard.max_bearing_deg = 2.0;
+    channels_.front().birth_guard.update_guard.max_euclidean_innovation_m = 5.0;
+    resetProcessor();
+  }
+
+  void resetProcessor()
+  {
+    processor_ = std::make_unique<Processor>(
+      tracker_configs_, creation_config_, association_config_, overlap_config_, channels_,
+      rclcpp::get_logger("birth_guard_test"),
+      std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME));
+  }
+
+  static rclcpp::Time baseTime()
+  {
+    return rclcpp::Time(1000000000LL, RCL_ROS_TIME);
+  }
+
+  mot::types::DynamicObject makeCar(
+    const double x, const double y, const rclcpp::Time & time, const std::string & id) const
+  {
+    mot::types::DynamicObject object;
+    object.uuid.uuid = stringToUUID(id);
+    object.time = time;
+    object.channel_index = 0;
+    object.existence_probability = 0.95F;
+    object.classification = {{mot::classes::Label::CAR, 1.0F}};
+    object.pose.position.x = x;
+    object.pose.position.y = y;
+    object.pose.orientation.w = 1.0;
+    object.pose_covariance.fill(0.0);
+    object.kinematics.has_position_covariance = false;
+    if (position_variance_ > 0.0) {
+      object.pose_covariance[0] = position_variance_;
+      object.pose_covariance[7] = position_variance_;
+      object.kinematics.has_position_covariance = true;
+    }
+    object.twist_covariance.fill(0.0);
+    object.kinematics.orientation_availability = mot::types::OrientationAvailability::AVAILABLE;
+    object.kinematics.has_twist = false;
+    object.kinematics.has_twist_covariance = false;
+    object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+    object.shape.dimensions.x = 4.8;
+    object.shape.dimensions.y = 2.0;
+    object.shape.dimensions.z = 1.5;
+    object.area = object.shape.dimensions.x * object.shape.dimensions.y;
+    return object;
+  }
+
+  mot::types::DynamicObjectList makeObjects(
+    const rclcpp::Time & time, std::vector<std::pair<double, double>> positions)
+  {
+    mot::types::DynamicObjectList objects;
+    objects.header.stamp = time;
+    objects.header.frame_id = "map";
+    objects.channel_index = 0;
+    for (const auto & [x, y] : positions) {
+      objects.objects.push_back(makeCar(x, y, time, "measurement_" + std::to_string(next_id_++)));
+    }
+    return objects;
+  }
+
+  void process(
+    const rclcpp::Time & time, std::vector<std::pair<double, double>> positions,
+    const bool ego_available = true)
+  {
+    if (ego_available) {
+      geometry_msgs::msg::PoseStamped ego;
+      ego.header.stamp = time;
+      ego.header.frame_id = "map";
+      ego.pose.orientation.w = 1.0;
+      processor_->updateEgoPose(ego);
+    } else {
+      processor_->updateEgoPose(std::nullopt);
+    }
+    processor_->predictTrackers(time);
+
+    auto objects = makeObjects(time, std::move(positions));
+    const auto association = processor_->associate(objects);
+    const mot::types::AssociatedObjects associated{objects, association};
+    processor_->update(associated);
+    processor_->prune(time);
+    processor_->spawn(associated);
+  }
+
+  void establishNearTracker(rclcpp::Time & time)
+  {
+    for (int i = 0; i < 4; ++i) {
+      process(time, {{10.0, 0.0}});
+      time += rclcpp::Duration(50ms);
+    }
+    ASSERT_EQ(processor_->getListTracker().size(), 1U);
+  }
+
+  void forceAssociatedUpdate(
+    const rclcpp::Time & time, const std::pair<double, double> position,
+    mot::types::DynamicObject * prediction_before_update = nullptr, const bool ego_available = true)
+  {
+    ASSERT_EQ(processor_->getListTracker().size(), 1U);
+    if (ego_available) {
+      geometry_msgs::msg::PoseStamped ego;
+      ego.header.stamp = time;
+      ego.header.frame_id = "map";
+      ego.pose.orientation.w = 1.0;
+      processor_->updateEgoPose(ego);
+    } else {
+      processor_->updateEgoPose(std::nullopt);
+    }
+    processor_->predictTrackers(time);
+
+    const auto tracker = processor_->getListTracker().front();
+    if (prediction_before_update) {
+      ASSERT_TRUE(tracker->getTrackedObject(time, *prediction_before_update, false));
+    }
+    auto objects = makeObjects(time, {position});
+    mot::types::AssociationResult association;
+    association.add(tracker->getUUID(), objects.objects.front().uuid);
+    const mot::types::AssociatedObjects associated{objects, association};
+    processor_->update(associated);
+    processor_->prune(time);
+    processor_->spawn(associated);
+  }
+
+  mot::TrackerConfigs tracker_configs_;
+  mot::TrackerCreationConfig creation_config_;
+  mot::TrackerAssociationConfig association_config_;
+  mot::TrackerOverlapManagerConfig overlap_config_;
+  std::vector<mot::types::InputChannel> channels_;
+  std::unique_ptr<Processor> processor_;
+  int next_id_{0};
+  double position_variance_{0.0};
+};
+
+TEST_F(BirthGuardTest, DisabledChannelKeepsImmediateSpawnBehavior)
+{
+  channels_.front().birth_guard.enabled = false;
+  resetProcessor();
+  auto time = baseTime();
+  establishNearTracker(time);
+
+  process(time, {{50.0, 0.0}});
+
+  EXPECT_EQ(processor_->getListTracker().size(), 2U);
+}
+
+TEST_F(BirthGuardTest, QuarantinesFarSameBearingBirthWhileEstablishedTrackerCoasts)
+{
+  auto time = baseTime();
+  establishNearTracker(time);
+
+  for (int i = 0; i < 4; ++i) {
+    process(time, {{50.0, 0.0}});
+    time += rclcpp::Duration(50ms);
+  }
+
+  EXPECT_EQ(processor_->getListTracker().size(), 1U);
+}
+
+TEST_F(BirthGuardTest, QuarantinesBirthWhileCoastingTrackerIsNotPublishConfident)
+{
+  // Camera inputs do not own existence probability.  A valid established track can therefore
+  // fall below the publish-confidence threshold after only a few rejected alternate-depth
+  // measurements, while it is still inside the configured conflict coast window.
+  channels_.front().trust_existence_probability = false;
+  position_variance_ = 4.0;
+  resetProcessor();
+  auto time = baseTime();
+  process(time, {{10.0, 0.0}});
+  time += rclcpp::Duration(50ms);
+  process(time, {{10.0, 0.0}});
+  ASSERT_EQ(processor_->getListTracker().size(), 1U);
+  ASSERT_EQ(processor_->getListTracker().front()->getTotalMeasurementCount(), 2);
+
+  time += rclcpp::Duration(50ms);
+  forceAssociatedUpdate(time, {20.0, 0.0});
+  ASSERT_EQ(processor_->getListTracker().front()->getNoMeasurementCount(), 1);
+  autoware_perception_msgs::msg::TrackedObjects published;
+  processor_->getTrackedObjects(time, published);
+  ASSERT_TRUE(published.objects.empty());
+
+  time += rclcpp::Duration(50ms);
+  process(time, {{50.0, 0.0}});
+
+  EXPECT_EQ(processor_->getListTracker().size(), 1U);
+}
+
+TEST_F(BirthGuardTest, DoesNotBlockASecondCarWhenEstablishedTrackerWasObserved)
+{
+  auto time = baseTime();
+  establishNearTracker(time);
+
+  process(time, {{10.0, 0.0}, {50.0, 0.0}});
+
+  EXPECT_EQ(processor_->getListTracker().size(), 2U);
+}
+
+TEST_F(BirthGuardTest, ReleasesConfirmedHypothesisAfterCoastConflictClears)
+{
+  auto time = baseTime();
+  establishNearTracker(time);
+
+  for (int i = 0; i < 3; ++i) {
+    process(time, {{50.0, 0.0}});
+    time += rclcpp::Duration(50ms);
+  }
+  ASSERT_EQ(processor_->getListTracker().size(), 1U);
+
+  process(time, {{10.0, 0.0}, {50.0, 0.0}});
+
+  EXPECT_EQ(processor_->getListTracker().size(), 2U);
+}
+
+TEST_F(BirthGuardTest, DoesNotTreatDifferentBearingAsDepthConflict)
+{
+  auto time = baseTime();
+  establishNearTracker(time);
+
+  process(time, {{0.0, 50.0}});
+
+  EXPECT_EQ(processor_->getListTracker().size(), 2U);
+}
+
+TEST_F(BirthGuardTest, CollinearSecondCarDelayEndsAtConfiguredCoastBound)
+{
+  channels_.front().birth_guard.conflict_max_coast_age_sec = 0.2;
+  resetProcessor();
+  auto time = baseTime();
+  establishNearTracker(time);
+
+  for (int i = 0; i < 4; ++i) {
+    process(time, {{50.0, 0.0}});
+    time += rclcpp::Duration(50ms);
+  }
+  ASSERT_EQ(processor_->getListTracker().size(), 1U);
+
+  process(time, {{50.0, 0.0}});
+
+  EXPECT_EQ(processor_->getListTracker().size(), 2U);
+}
+
+TEST_F(BirthGuardTest, WithholdsImpossibleSameBearingAssociatedUpdateWithoutSpawning)
+{
+  auto time = baseTime();
+  establishNearTracker(time);
+  const auto tracker = processor_->getListTracker().front();
+  const int measurements_before = tracker->getTotalMeasurementCount();
+
+  mot::types::DynamicObject prediction_before_update;
+  forceAssociatedUpdate(time, {14.5, 0.0}, &prediction_before_update);
+
+  ASSERT_EQ(processor_->getListTracker().size(), 1U);
+  EXPECT_EQ(tracker->getTotalMeasurementCount(), measurements_before);
+  EXPECT_EQ(tracker->getNoMeasurementCount(), 1);
+  mot::types::DynamicObject state_after_update;
+  ASSERT_TRUE(tracker->getTrackedObject(time, state_after_update, false));
+  EXPECT_NEAR(state_after_update.pose.position.x, prediction_before_update.pose.position.x, 1e-9);
+  EXPECT_NEAR(state_after_update.pose.position.y, prediction_before_update.pose.position.y, 1e-9);
+}
+
+TEST_F(BirthGuardTest, AcceptsLaterValidUpdateAfterRejectedDepthMode)
+{
+  auto time = baseTime();
+  establishNearTracker(time);
+  const auto tracker = processor_->getListTracker().front();
+
+  forceAssociatedUpdate(time, {14.5, 0.0});
+  const int measurements_after_rejection = tracker->getTotalMeasurementCount();
+  time += rclcpp::Duration(50ms);
+  forceAssociatedUpdate(time, {10.2, 0.0});
+
+  EXPECT_EQ(tracker->getTotalMeasurementCount(), measurements_after_rejection + 1);
+  EXPECT_EQ(tracker->getNoMeasurementCount(), 0);
+  EXPECT_EQ(processor_->getListTracker().size(), 1U);
+}
+
+TEST_F(BirthGuardTest, NormalAssociatedUpdateRemainsAccepted)
+{
+  auto time = baseTime();
+  establishNearTracker(time);
+  const auto tracker = processor_->getListTracker().front();
+  const int measurements_before = tracker->getTotalMeasurementCount();
+
+  forceAssociatedUpdate(time, {10.4, 0.0});
+
+  EXPECT_EQ(tracker->getTotalMeasurementCount(), measurements_before + 1);
+  EXPECT_EQ(tracker->getNoMeasurementCount(), 0);
+}
+
+TEST_F(BirthGuardTest, DisabledUpdateGuardKeepsAssociatedUpdateBehavior)
+{
+  channels_.front().birth_guard.update_guard.enabled = false;
+  resetProcessor();
+  auto time = baseTime();
+  establishNearTracker(time);
+  const auto tracker = processor_->getListTracker().front();
+  const int measurements_before = tracker->getTotalMeasurementCount();
+
+  forceAssociatedUpdate(time, {14.5, 0.0});
+
+  EXPECT_EQ(tracker->getTotalMeasurementCount(), measurements_before + 1);
+  EXPECT_EQ(tracker->getNoMeasurementCount(), 0);
+}
+
+TEST_F(BirthGuardTest, VelocityBootstrapAcceptsMotionBeforeMinimumMeasurements)
+{
+  auto time = baseTime();
+  process(time, {{10.0, 0.0}});
+  ASSERT_EQ(processor_->getListTracker().size(), 1U);
+  const auto tracker = processor_->getListTracker().front();
+  ASSERT_EQ(tracker->getTotalMeasurementCount(), 1);
+
+  time += rclcpp::Duration(50ms);
+  forceAssociatedUpdate(time, {14.0, 0.0});
+
+  EXPECT_EQ(tracker->getTotalMeasurementCount(), 2);
+  EXPECT_EQ(tracker->getNoMeasurementCount(), 0);
+}
+
+TEST_F(BirthGuardTest, LongCoastCannotGrowRadialAllowancePastCap)
+{
+  auto time = baseTime();
+  establishNearTracker(time);
+  const auto tracker = processor_->getListTracker().front();
+  const int measurements_before = tracker->getTotalMeasurementCount();
+
+  time += rclcpp::Duration(300ms);
+  forceAssociatedUpdate(time, {14.75, 0.0});
+
+  EXPECT_EQ(tracker->getTotalMeasurementCount(), measurements_before);
+  EXPECT_EQ(tracker->getNoMeasurementCount(), 1);
+}
+
+TEST_F(BirthGuardTest, MissingEgoUsesLooseEuclideanCap)
+{
+  auto time = baseTime();
+  establishNearTracker(time);
+  auto tracker = processor_->getListTracker().front();
+  int measurements_before = tracker->getTotalMeasurementCount();
+
+  forceAssociatedUpdate(time, {14.0, 0.0}, nullptr, false);
+
+  EXPECT_EQ(tracker->getTotalMeasurementCount(), measurements_before + 1);
+  EXPECT_EQ(tracker->getNoMeasurementCount(), 0);
+
+  resetProcessor();
+  time = baseTime();
+  establishNearTracker(time);
+  tracker = processor_->getListTracker().front();
+  measurements_before = tracker->getTotalMeasurementCount();
+
+  forceAssociatedUpdate(time, {15.1, 0.0}, nullptr, false);
+
+  EXPECT_EQ(tracker->getTotalMeasurementCount(), measurements_before);
+  EXPECT_EQ(tracker->getNoMeasurementCount(), 1);
+  EXPECT_EQ(processor_->getListTracker().size(), 1U);
+}
+
+TEST_F(BirthGuardTest, LooseEuclideanCapRejectsHugeJumpJustOutsideBearingGate)
+{
+  auto time = baseTime();
+  establishNearTracker(time);
+  const auto tracker = processor_->getListTracker().front();
+  const int measurements_before = tracker->getTotalMeasurementCount();
+  constexpr double angle_rad = 2.1 * 3.14159265358979323846 / 180.0;
+
+  forceAssociatedUpdate(time, {20.0 * std::cos(angle_rad), 20.0 * std::sin(angle_rad)});
+
+  EXPECT_EQ(tracker->getTotalMeasurementCount(), measurements_before);
+  EXPECT_EQ(tracker->getNoMeasurementCount(), 1);
+  EXPECT_EQ(processor_->getListTracker().size(), 1U);
+}
+
+TEST(BirthGuardConfigValidation, RejectsEveryNonFiniteDouble)
+{
+  using Config = mot::types::InputChannel::BirthGuard;
+  constexpr std::array<double Config::*, 6> birth_double_fields = {
+    &Config::hypothesis_timeout_sec,
+    &Config::hypothesis_match_distance_m,
+    &Config::hypothesis_max_speed_mps,
+    &Config::conflict_max_coast_age_sec,
+    &Config::conflict_min_range_gap_m,
+    &Config::conflict_max_bearing_deg,
+  };
+  using UpdateConfig = Config::UpdateGuard;
+  constexpr std::array<double UpdateConfig::*, 6> update_double_fields = {
+    &UpdateConfig::base_allowance_m,
+    &UpdateConfig::max_innovation_speed_mps,
+    &UpdateConfig::max_elapsed_sec,
+    &UpdateConfig::max_allowance_m,
+    &UpdateConfig::max_bearing_deg,
+    &UpdateConfig::max_euclidean_innovation_m,
+  };
+
+  EXPECT_TRUE(mot::types::isValidBirthGuardConfig(Config{}));
+  for (const auto field : birth_double_fields) {
+    for (const double invalid : {
+           std::numeric_limits<double>::quiet_NaN(),
+           std::numeric_limits<double>::infinity(),
+           -std::numeric_limits<double>::infinity()}) {
+      Config config;
+      config.*field = invalid;
+      EXPECT_FALSE(mot::types::isValidBirthGuardConfig(config));
+    }
+  }
+  for (const auto field : update_double_fields) {
+    for (const double invalid : {
+           std::numeric_limits<double>::quiet_NaN(),
+           std::numeric_limits<double>::infinity(),
+           -std::numeric_limits<double>::infinity()}) {
+      Config config;
+      config.update_guard.*field = invalid;
+      EXPECT_FALSE(mot::types::isValidBirthGuardConfig(config));
+    }
+  }
+
+  Config allowance_order;
+  allowance_order.update_guard.max_allowance_m =
+    allowance_order.update_guard.base_allowance_m - 0.1;
+  EXPECT_FALSE(mot::types::isValidBirthGuardConfig(allowance_order));
+
+  Config insufficient_bootstrap;
+  insufficient_bootstrap.update_guard.min_measurements = 2;
+  EXPECT_FALSE(mot::types::isValidBirthGuardConfig(insufficient_bootstrap));
+
+  Config euclidean_order;
+  euclidean_order.update_guard.max_euclidean_innovation_m =
+    euclidean_order.update_guard.max_allowance_m - 0.1;
+  EXPECT_FALSE(mot::types::isValidBirthGuardConfig(euclidean_order));
+}
+
+TEST_F(BirthGuardTest, MissingEgoPoseWithholdsBirthUntilGeometryReturns)
+{
+  auto time = baseTime();
+  for (int i = 0; i < 3; ++i) {
+    process(time, {{30.0, 0.0}}, false);
+    time += rclcpp::Duration(50ms);
+  }
+  ASSERT_TRUE(processor_->getListTracker().empty());
+
+  process(time, {{30.0, 0.0}});
+
+  EXPECT_EQ(processor_->getListTracker().size(), 1U);
+}
+
+TEST_F(BirthGuardTest, RejectsNonFiniteMeasurementPositions)
+{
+  const std::vector<std::pair<double, double>> invalid_positions = {
+    {std::numeric_limits<double>::quiet_NaN(), 0.0},
+    {0.0, std::numeric_limits<double>::infinity()},
+    {-std::numeric_limits<double>::infinity(), 0.0},
+  };
+
+  auto time = baseTime();
+  for (const auto & position : invalid_positions) {
+    process(time, {position});
+    time += rclcpp::Duration(50ms);
+  }
+  EXPECT_TRUE(processor_->getListTracker().empty());
+
+  process(time, {{30.0, 0.0}});
+  EXPECT_EQ(processor_->getListTracker().size(), 1U);
+}
+
+}  // namespace

--- a/perception/autoware_multi_object_tracker/test/test_birth_guard.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_birth_guard.cpp
@@ -263,6 +263,56 @@ TEST_F(BirthGuardTest, DoesNotBlockASecondCarWhenEstablishedTrackerWasObserved)
   EXPECT_EQ(processor_->getListTracker().size(), 2U);
 }
 
+TEST_F(BirthGuardTest, SingleOpponentModeBlocksOppositeBearingBirthWhileTrackerWasObserved)
+{
+  channels_.front().birth_guard.single_opponent_mode = true;
+  resetProcessor();
+  auto time = baseTime();
+  establishNearTracker(time);
+
+  // This is the failure shape seen in the rear camera replay: the valid opponent continues to
+  // update while an unrelated, geometrically smooth false branch appears at another bearing.
+  // Generic same-ray birth protection intentionally allows it, but known 1v1 operation must not.
+  for (int i = 0; i < 6; ++i) {
+    process(time, {{10.0, 0.0}, {0.0, -35.0}});
+    time += rclcpp::Duration(50ms);
+  }
+
+  EXPECT_EQ(processor_->getListTracker().size(), 1U);
+}
+
+TEST_F(BirthGuardTest, SingleOpponentModeAllowsOnlyOneInitialTrackerPerMessage)
+{
+  channels_.front().birth_guard.single_opponent_mode = true;
+  resetProcessor();
+  const auto time = baseTime();
+
+  process(time, {{10.0, 0.0}, {0.0, -35.0}});
+
+  EXPECT_EQ(processor_->getListTracker().size(), 1U);
+}
+
+TEST_F(BirthGuardTest, SingleOpponentModeReleasesConfirmedReplacementAfterIncumbentExpires)
+{
+  channels_.front().birth_guard.single_opponent_mode = true;
+  resetProcessor();
+  auto time = baseTime();
+  establishNearTracker(time);
+
+  // Keep the replacement hypothesis coherent while the incumbent follows its normal bounded
+  // one-second coast.  It may be released only after prune() removes the incumbent.
+  for (int i = 0; i < 24; ++i) {
+    process(time, {{0.0, -35.0}});
+    time += rclcpp::Duration(50ms);
+  }
+
+  ASSERT_EQ(processor_->getListTracker().size(), 1U);
+  mot::types::DynamicObject replacement;
+  ASSERT_TRUE(processor_->getListTracker().front()->getTrackedObject(time, replacement, false));
+  EXPECT_NEAR(replacement.pose.position.x, 0.0, 1e-6);
+  EXPECT_NEAR(replacement.pose.position.y, -35.0, 1e-6);
+}
+
 TEST_F(BirthGuardTest, ReleasesConfirmedHypothesisAfterCoastConflictClears)
 {
   auto time = baseTime();

--- a/perception/autoware_multi_object_tracker/test/test_detection_subscription_qos.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_detection_subscription_qos.cpp
@@ -1,0 +1,47 @@
+// Copyright 2020 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/detection_subscription_qos.hpp"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+namespace input_qos = ::autoware::multi_object_tracker::input_qos;
+
+TEST(DetectionSubscriptionQos, PreservesTheUpstreamDefault)
+{
+  EXPECT_EQ(input_qos::kDepthDefault, 1);
+  EXPECT_EQ(input_qos::detectionQos(input_qos::kDepthDefault).depth(), 1u);
+}
+
+TEST(DetectionSubscriptionQos, AcceptsUsefulKeepLastDepths)
+{
+  for (const int depth : {1, 2, 10, 100, 1000}) {
+    EXPECT_TRUE(input_qos::isValidDepth(depth));
+    const auto qos = input_qos::detectionQos(depth);
+    EXPECT_EQ(qos.depth(), static_cast<size_t>(depth));
+    EXPECT_EQ(qos.history(), rclcpp::HistoryPolicy::KeepLast);
+  }
+}
+
+TEST(DetectionSubscriptionQos, RefusesInvalidDepths)
+{
+  for (const int depth : {
+         0, -1, 1001, std::numeric_limits<int>::min(), std::numeric_limits<int>::max()}) {
+    EXPECT_FALSE(input_qos::isValidDepth(depth));
+    EXPECT_THROW(input_qos::requireValidDepth(depth), std::invalid_argument);
+    EXPECT_THROW(input_qos::detectionQos(depth), std::invalid_argument);
+  }
+}

--- a/perception/autoware_multi_object_tracker/test/test_input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_input_manager.cpp
@@ -1,0 +1,55 @@
+// Copyright 2026 Alex Nan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/processor/input_manager.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+
+namespace autoware::multi_object_tracker
+{
+namespace
+{
+
+using namespace std::chrono_literals;
+
+TEST(InputStream, ConsumesAnItemAtTheInclusiveCutoffExactlyOnce)
+{
+  types::InputChannel channel;
+  channel.index = 0;
+  channel.long_name = "test camera";
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  InputStream stream(channel, nullptr, rclcpp::get_logger("input_manager_test"), clock);
+
+  const rclcpp::Time stamp = clock->now();
+  types::DynamicObjectList objects;
+  objects.header.stamp = stamp;
+  objects.channel_index = channel.index;
+  stream.push(objects, types::AssociationResult{});
+
+  types::ObjectsWithAssociationList first_export;
+  stream.getObjectsOlderThan(stamp, stamp - rclcpp::Duration(1s), first_export);
+  ASSERT_EQ(first_export.size(), 1U);
+
+  types::ObjectsWithAssociationList second_export;
+  stream.getObjectsOlderThan(stamp, stamp - rclcpp::Duration(1s), second_export);
+  EXPECT_TRUE(second_export.empty());
+}
+
+}  // namespace
+}  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -243,6 +243,68 @@ TEST(VehicleUpdatePath, CenterPositionKeepsNominalLengthThroughTurnsAndPredictio
   }
 }
 
+TEST(VehicleUpdatePath, CenterOnlyBirthLocksNominalLengthBeforeSecondMeasurement)
+{
+  constexpr double nominal_length = 4.5718;
+  const rclcpp::Time t0{0, 0, RCL_ROS_TIME};
+  auto initial = makeCenterObject(0.0, 0.0, nominal_length, 1.8);
+  initial.trust_extension = false;
+  initial.trust_position_as_center = true;
+  initial.kinematics.has_twist = true;
+  initial.twist.linear.x = 25.0;
+  initial.twist.linear.y = 3.0;
+  initial.twist_covariance.fill(0.0);
+  initial.twist_covariance[0] = 0.25;
+  initial.twist_covariance[7] = 0.25;
+
+  VehicleTracker tracker(object_model::normal_vehicle, t0, initial);
+
+  // A lateral-velocity state evolves the two bicycle endpoints differently.
+  // The center-only birth policy must therefore be active before a second
+  // measurement arrives, including through an immediate detection gap.
+  for (int i = 1; i <= 10; ++i) {
+    const rclcpp::Time time{static_cast<int64_t>(i) * 100000000, RCL_ROS_TIME};
+    ASSERT_TRUE(tracker.predict(time));
+    types::DynamicObject output;
+    ASSERT_TRUE(tracker.getTrackedObject(time, output));
+    EXPECT_NEAR(output.shape.dimensions.x, nominal_length, 1.0e-9) << "step " << i;
+  }
+}
+
+TEST(VehicleUpdatePath, TrustedNormalUpdateRefreshesLockedNominalLength)
+{
+  const rclcpp::Time t0{0, 0, RCL_ROS_TIME};
+  const rclcpp::Time t1{static_cast<int64_t>(100000000), RCL_ROS_TIME};
+  const rclcpp::Time t2{static_cast<int64_t>(200000000), RCL_ROS_TIME};
+  auto initial = makeCenterObject(0.0, 0.0, 4.0, 1.8);
+  initial.trust_extension = false;
+  initial.trust_position_as_center = true;
+  VehicleTracker tracker(object_model::normal_vehicle, t0, initial);
+
+  types::InputChannel trusted_channel{};
+  trusted_channel.index = 1;
+  trusted_channel.trust_extension = true;
+  trusted_channel.trust_orientation = false;
+  trusted_channel.trust_position_as_center = false;
+
+  auto trusted_measurement = makeCenterObject(0.0, 0.0, 6.0, 1.9);
+  trusted_measurement.channel_index = trusted_channel.index;
+  trusted_measurement.trust_extension = true;
+
+  ASSERT_TRUE(tracker.predict(t1));
+  ASSERT_TRUE(tracker.measure(trusted_measurement, t1, trusted_channel));
+
+  types::DynamicObject after_measurement;
+  ASSERT_TRUE(tracker.getTrackedObject(t1, after_measurement));
+  ASSERT_GT(after_measurement.shape.dimensions.x, initial.shape.dimensions.x + 0.1);
+
+  ASSERT_TRUE(tracker.predict(t2));
+  types::DynamicObject after_prediction;
+  ASSERT_TRUE(tracker.getTrackedObject(t2, after_prediction));
+  EXPECT_NEAR(
+    after_prediction.shape.dimensions.x, after_measurement.shape.dimensions.x, 1.0e-9);
+}
+
 TEST(TrackerExistenceProbability, RepeatedMissesDecayOnlyOverIncrementalIntervals)
 {
   constexpr float initial_probability = 0.8F;

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -13,9 +13,16 @@
 // limitations under the License.
 
 #include "autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
+#include "autoware/multi_object_tracker/tracker/trackers/multiple_vehicle_tracker.hpp"
+#include "autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp"
+#include "autoware/multi_object_tracker/types.hpp"
 
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <gtest/gtest.h>
+#include <rclcpp/time.hpp>
 
+#include <array>
 #include <cmath>
 
 namespace autoware::multi_object_tracker
@@ -52,7 +59,214 @@ double expectedVar(double tracker_width, double polygon_width)
   const double half_dead_zone = 0.5 * std::abs(polygon_width - tracker_width);
   return half_dead_zone * half_dead_zone;
 }
+
+types::DynamicObject makeCenterObject(
+  const double x, const double y, const double length = 4.5718,
+  const double width = 1.8)
+{
+  types::DynamicObject object;
+  object.channel_index = 0;
+  object.existence_probability = 0.9F;
+  object.classification = {{classes::Label::CAR, 1.0F}};
+  object.pose.position.x = x;
+  object.pose.position.y = y;
+  object.pose.orientation.w = 1.0;
+  object.pose_covariance.fill(0.0);
+  object.pose_covariance[0] = 0.01;
+  object.pose_covariance[7] = 0.01;
+  object.pose_covariance[14] = 1.0;
+  object.pose_covariance[21] = 1.0e6;
+  object.pose_covariance[28] = 1.0e6;
+  object.pose_covariance[35] = 1.0e6;
+  object.kinematics.has_position_covariance = true;
+  object.kinematics.orientation_availability = types::OrientationAvailability::UNAVAILABLE;
+  object.kinematics.has_twist = false;
+  object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  object.shape.dimensions.x = length;
+  object.shape.dimensions.y = width;
+  object.shape.dimensions.z = 1.2573;
+  object.trust_extension = false;
+  object.area = length * width;
+  return object;
+}
 }  // namespace
+
+TEST(VehicleUpdatePath, CenterTrustIsIndependentOfExtensionAndOrientation)
+{
+  const rclcpp::Time time{0, 0, RCL_ROS_TIME};
+  const auto object = makeCenterObject(0.0, 0.0);
+  VehicleTracker tracker(object_model::normal_vehicle, time, object);
+
+  types::InputChannel channel{};
+  channel.trust_extension = false;
+  channel.trust_orientation = false;
+  channel.trust_position_as_center = false;
+  EXPECT_EQ(tracker.selectUpdatePath(channel, false), UpdatePath::CONDITIONED);
+
+  channel.trust_position_as_center = true;
+  EXPECT_EQ(tracker.selectUpdatePath(channel, false), UpdatePath::CENTER_POSITION);
+  EXPECT_EQ(tracker.selectUpdatePath(channel, true), UpdatePath::CENTER_POSITION);
+
+  channel.trust_extension = true;
+  EXPECT_EQ(tracker.selectUpdatePath(channel, false), UpdatePath::NORMAL);
+  EXPECT_EQ(tracker.selectUpdatePath(channel, true), UpdatePath::TRY_EXTENSION);
+
+  channel.trust_position_as_center = false;
+  EXPECT_EQ(tracker.selectUpdatePath(channel, false), UpdatePath::NORMAL);
+  EXPECT_EQ(tracker.selectUpdatePath(channel, true), UpdatePath::TRY_EXTENSION);
+}
+
+TEST(VehicleUpdatePath, MultipleVehicleTrackerUsesTheSameCenterPolicy)
+{
+  const rclcpp::Time time{0, 0, RCL_ROS_TIME};
+  const auto object = makeCenterObject(0.0, 0.0);
+  MultipleVehicleTracker tracker(time, object);
+
+  types::InputChannel channel{};
+  channel.trust_extension = false;
+  channel.trust_orientation = false;
+  EXPECT_EQ(tracker.selectUpdatePath(channel, false), UpdatePath::CONDITIONED);
+
+  channel.trust_position_as_center = true;
+  EXPECT_EQ(tracker.selectUpdatePath(channel, false), UpdatePath::CENTER_POSITION);
+
+  channel.trust_extension = true;
+  EXPECT_EQ(tracker.selectUpdatePath(channel, false), UpdatePath::NORMAL);
+  EXPECT_EQ(tracker.selectUpdatePath(channel, true), UpdatePath::TRY_EXTENSION);
+}
+
+TEST(VehicleUpdatePath, CenterUpdateDoesNotTrustNominalShapeOrYaw)
+{
+  const rclcpp::Time t0{0, 0, RCL_ROS_TIME};
+  const rclcpp::Time t1{static_cast<int64_t>(100000000), RCL_ROS_TIME};
+  const auto initial = makeCenterObject(0.0, 0.0);
+  VehicleTracker tracker(object_model::normal_vehicle, t0, initial);
+
+  types::InputChannel channel{};
+  channel.index = 0;
+  channel.trust_extension = false;
+  channel.trust_orientation = false;
+  channel.trust_position_as_center = true;
+
+  auto measurement = makeCenterObject(0.0, 1.5, 9.0, 3.0);
+  measurement.shape.footprint.points.resize(4);
+  measurement.shape.footprint.points[0].x = 4.5F;
+  measurement.shape.footprint.points[0].y = 1.5F;
+  measurement.shape.footprint.points[1].x = 4.5F;
+  measurement.shape.footprint.points[1].y = -1.5F;
+  measurement.shape.footprint.points[2].x = -4.5F;
+  measurement.shape.footprint.points[2].y = -1.5F;
+  measurement.shape.footprint.points[3].x = -4.5F;
+  measurement.shape.footprint.points[3].y = 1.5F;
+  ASSERT_TRUE(tracker.predict(t1));
+  ASSERT_TRUE(tracker.updateWithMeasurement(measurement, t1, channel));
+
+  types::DynamicObject output;
+  ASSERT_TRUE(tracker.getTrackedObject(t1, output));
+  // The Kalman gain need not move all the way to a single measurement, but the
+  // update must consume that measurement as a center pose rather than inventing
+  // an edge/wheel anchor.
+  EXPECT_GT(output.pose.position.y, 0.5);
+  EXPECT_NEAR(output.pose.position.x, 0.0, 1.0e-6);
+  // The motion model carries length as a state, so prediction can introduce a
+  // tiny numerical change.  It must nevertheless retain the tracked size and
+  // reject the measurement's deliberately bogus 9 m x 3 m dimensions.
+  EXPECT_NEAR(output.shape.dimensions.x, initial.shape.dimensions.x, 1.0e-3);
+  EXPECT_NEAR(output.shape.dimensions.y, initial.shape.dimensions.y, 1.0e-6);
+  EXPECT_TRUE(output.shape.footprint.points.empty());
+  EXPECT_EQ(
+    output.kinematics.orientation_availability, types::OrientationAvailability::UNAVAILABLE);
+  EXPECT_FALSE(output.trust_extension);
+}
+
+TEST(VehicleUpdatePath, CenterOnlyChannelDoesNotEraseTrustedExtensionState)
+{
+  const rclcpp::Time t0{0, 0, RCL_ROS_TIME};
+  const rclcpp::Time t1{static_cast<int64_t>(100000000), RCL_ROS_TIME};
+  auto initial = makeCenterObject(0.0, 0.0);
+  initial.trust_extension = true;
+  VehicleTracker tracker(object_model::normal_vehicle, t0, initial);
+
+  types::InputChannel center_only_channel{};
+  center_only_channel.index = 0;
+  center_only_channel.trust_extension = false;
+  center_only_channel.trust_orientation = false;
+  center_only_channel.trust_position_as_center = true;
+
+  auto measurement = makeCenterObject(0.0, 1.0, 9.0, 3.0);
+  ASSERT_TRUE(tracker.predict(t1));
+  ASSERT_TRUE(tracker.updateWithMeasurement(measurement, t1, center_only_channel));
+
+  types::DynamicObject output;
+  ASSERT_TRUE(tracker.getTrackedObject(t1, output));
+  EXPECT_TRUE(output.trust_extension);
+  EXPECT_NEAR(output.shape.dimensions.x, initial.shape.dimensions.x, 1.0e-3);
+  EXPECT_NEAR(output.shape.dimensions.y, initial.shape.dimensions.y, 1.0e-6);
+}
+
+TEST(VehicleUpdatePath, CenterPositionKeepsNominalLengthThroughTurnsAndPredictionGaps)
+{
+  constexpr double nominal_length = 4.5718;
+  constexpr double radius = 30.0;
+  constexpr double speed = 25.0;
+  constexpr int64_t step_ns = 50000000;  // 20 Hz prediction
+  const rclcpp::Time t0{0, 0, RCL_ROS_TIME};
+  auto initial = makeCenterObject(0.0, 0.0, nominal_length, 1.8);
+  VehicleTracker tracker(object_model::normal_vehicle, t0, initial);
+
+  types::InputChannel channel{};
+  channel.index = 0;
+  channel.trust_extension = false;
+  channel.trust_orientation = false;
+  channel.trust_position_as_center = true;
+
+  // A 30 m-radius arc continually rotates the inferred heading. Measurements
+  // arrive at 5 Hz while prediction runs at 20 Hz, exercising repeated gaps
+  // that previously let the two bicycle endpoints separate.
+  for (int i = 1; i <= 800; ++i) {
+    const rclcpp::Time t{static_cast<int64_t>(i) * step_ns, RCL_ROS_TIME};
+    ASSERT_TRUE(tracker.predict(t));
+    if (i == 1 || i % 4 == 0) {
+      const double elapsed_s = static_cast<double>(i * step_ns) * 1.0e-9;
+      const double angle = speed * elapsed_s / radius;
+      auto measurement = makeCenterObject(
+        radius * std::sin(angle), radius * (1.0 - std::cos(angle)),
+        // Deliberately bogus alternating dimensions must remain untrusted.
+        (i % 8 == 0) ? 20.0 : 1.0, 3.0);
+      ASSERT_TRUE(tracker.updateWithMeasurement(measurement, t, channel));
+    }
+
+    types::DynamicObject output;
+    ASSERT_TRUE(tracker.getTrackedObject(t, output));
+    EXPECT_TRUE(std::isfinite(output.shape.dimensions.x));
+    EXPECT_NEAR(output.shape.dimensions.x, nominal_length, 1.0e-9) << "step " << i;
+  }
+}
+
+TEST(TrackerExistenceProbability, RepeatedMissesDecayOnlyOverIncrementalIntervals)
+{
+  constexpr float initial_probability = 0.8F;
+  constexpr double half_life_s = 0.5;
+  constexpr int64_t step_ns = 100000000;  // 100 ms
+
+  const rclcpp::Time t0{0, 0, RCL_ROS_TIME};
+  VehicleTracker repeated(object_model::normal_vehicle, t0, makeCenterObject(0.0, 0.0));
+  VehicleTracker single(object_model::normal_vehicle, t0, makeCenterObject(0.0, 0.0));
+  repeated.initializeExistenceProbabilities(0, initial_probability);
+  single.initializeExistenceProbabilities(0, initial_probability);
+
+  for (int i = 1; i <= 3; ++i) {
+    ASSERT_TRUE(repeated.updateWithoutMeasurement(rclcpp::Time{i * step_ns, RCL_ROS_TIME}));
+  }
+  ASSERT_TRUE(single.updateWithoutMeasurement(rclcpp::Time{3 * step_ns, RCL_ROS_TIME}));
+
+  const double elapsed_s = 3.0 * static_cast<double>(step_ns) * 1.0e-9;
+  const float expected =
+    static_cast<float>(initial_probability * std::exp(std::log(0.5) * elapsed_s / half_life_s));
+  EXPECT_NEAR(repeated.getTotalExistenceProbability(), expected, 1.0e-6F);
+  EXPECT_NEAR(
+    repeated.getTotalExistenceProbability(), single.getTotalExistenceProbability(), 1.0e-6F);
+}
 
 // Equal widths: zero dead-zone, the two candidate centers coincide -> anchor untouched, no
 // variance.


### PR DESCRIPTION
## Description

- Treat fused camera positions as full-object centers without trusting monocular shape or yaw.
- Keep race-car dimensions fixed through updates, prediction gaps, and center-only tracker births.
- Refresh the locked nominal length after a trusted bounding-box update.
- Reject physically implausible same-bearing depth changes and prevent duplicate births while an established track coasts.
- Enforce the configured single-opponent birth policy for 1v1 camera operation.
- Consume each input measurement once and decay existence probability over incremental time.

## How was this PR tested?

- Release build of autoware_multi_object_tracker with tests enabled.
- Full tracker test binary: 50 passed, 0 failed; 4 disabled benchmark cases.
- Colcon result: 267 tests, 0 errors, 0 failures; 109 skipped, including disabled benchmarks and unavailable cppcheck.
- The production track_reprojection camera-channel YAML validates against the updated JSON schema.
- git diff --check passed.

## Notes for reviewers

This is a clean production diff against art-jazzy; old continuity-trace and experiment-only code are excluded. Guards are channel-configurable and disabled unless enabled in the input-channel configuration.

## Interface changes

No topic or message-type changes. Adds camera-channel center-position trust, bounded birth/update guard settings, single-opponent birth policy, and configurable detection subscription history depth.

## Effects on system behavior

When enabled for the camera channel, large same-bearing depth jumps are withheld while the existing track coasts, and a second tracker with the same semantic label cannot be born during known 1v1 operation. Normal updates and non-camera channels retain their previous behavior.