### PR TITLE
Make tracker coast and speed limits configurable

### DIFF
--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -8,6 +8,10 @@
     publish_on_timer: false
     publish_rate: 10.0
 
+    # Startup-only motion/coast limits. Defaults preserve upstream road-vehicle behavior.
+    tracker_expiration_time_s: 1.0
+    general_vehicle_max_speed_mps: 38.8888888889
+
     # ego pose source: "tf" (look up from TF tree) or "odometry" (interpolate from ~/input/odometry)
     ego_source: tf
     # delay compensation, least -> most:

--- a/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
+++ b/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
@@ -104,6 +104,12 @@ param_values:
   - name: publish_merged_objects
     type: boolean
     default: false
+  - name: tracker_expiration_time_s
+    type: double
+    default: 1.0
+  - name: general_vehicle_max_speed_mps
+    type: double
+    default: 38.8888888889
   - name: ego_source
     type: string
     default: tf

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/tracker_base.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/tracker_base.hpp
@@ -130,7 +130,8 @@ public:
     const std::optional<rclcpp::Time> & time) const;
   bool isExpired(
     const rclcpp::Time & time, const AdaptiveThresholdCache & cache,
-    const std::optional<geometry_msgs::msg::Pose> & ego_pose) const;
+    const std::optional<geometry_msgs::msg::Pose> & ego_pose,
+    double expiration_time_s = 1.0) const;
   float getKnownObjectProbability() const;
   double getPositionCovarianceDeterminant() const;
   virtual types::TrackerType getTrackerType() const { return tracker_type_; }

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/tracker_base.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/tracker_base.cpp
@@ -530,14 +530,19 @@ bool Tracker::isConfident(
 
 bool Tracker::isExpired(
   const rclcpp::Time & time, const AdaptiveThresholdCache & cache,
-  const std::optional<geometry_msgs::msg::Pose> & ego_pose) const
+  const std::optional<geometry_msgs::msg::Pose> & ego_pose,
+  const double expiration_time_s) const
 {
   // check the number of no measurements
   const double elapsed_time = getElapsedTimeFromLastUpdate(time);
 
   // if the last measurement is too old, the tracker is expired
-  constexpr double EXPIRED_TIME_THRESHOLD = 1.0;  // [sec]
-  if (elapsed_time > EXPIRED_TIME_THRESHOLD) {
+  if (!std::isfinite(expiration_time_s) || expiration_time_s <= 0.0 ||
+    expiration_time_s > 2.0)
+  {
+    return true;
+  }
+  if (elapsed_time > expiration_time_s) {
     return true;
   }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -141,6 +141,10 @@ VehicleTracker::VehicleTracker(
 
     motion_model_.initialize(
       time, x, y, yaw, pose_cov, vel_x, vel_x_cov, vel_y, vel_y_cov, initial_length);
+    // Apply the configured physical limits at birth as well as after later
+    // measurement updates. Otherwise an over-limit input twist survives until
+    // the next measurement callback.
+    motion_model_.limitStates();
     motion_model_.setZ(object.pose.position.z);
   }
 }

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -141,6 +141,20 @@
           "description": "KEEP_LAST history depth for each detected-object subscription.",
           "default": 1
         },
+        "tracker_expiration_time_s": {
+          "type": "number",
+          "exclusiveMinimum": 0.0,
+          "maximum": 2.0,
+          "description": "Hard tracker expiry after the last measurement, in seconds. Startup-only.",
+          "default": 1.0
+        },
+        "general_vehicle_max_speed_mps": {
+          "type": "number",
+          "exclusiveMinimum": 0.0,
+          "maximum": 120.0,
+          "description": "Longitudinal speed limit for GeneralVehicle motion models, in m/s. Startup-only.",
+          "default": 38.8888888889
+        },
         "world_frame_id": {
           "type": "string",
           "description": "Object kinematics definition frame.",

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -51,7 +51,8 @@ void MultiObjectTrackerInternalState::init(
   processor = std::make_unique<TrackerProcessor>(
     params.tracker_configs, params.creation_config, params.association_config,
     params.tracker_overlap_manager_config, params.input_channels_config, node.get_logger(),
-    node.get_clock());
+    node.get_clock(), params.tracker_expiration_time_s,
+    params.general_vehicle_max_speed_mps);
 
   last_publish_time = node.now();
   last_updated_time = node.now();

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.hpp
@@ -50,6 +50,13 @@ struct MultiObjectTrackerParameters
   bool enable_odometry_uncertainty;
   bool publish_processing_time_detail;
   bool publish_merged_objects;
+  // Maximum bounded prediction/coast interval after the most recent
+  // measurement. Vehicle trackers continue their bicycle-model linear/yaw-rate
+  // prediction during this interval; the default preserves upstream behavior.
+  double tracker_expiration_time_s{1.0};
+  // GeneralVehicle is the tracker used for CAR detections. Keep the upstream
+  // 140 km/h default unless a high-speed application explicitly raises it.
+  double general_vehicle_max_speed_mps{140.0 / 3.6};
 
   // ego pose sourcing
   EgoSource ego_source;

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -85,6 +85,31 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   params_.publish_processing_time_detail =
     declare_parameter<bool>("publish_processing_time_detail");
   params_.publish_merged_objects = declare_parameter<bool>("publish_merged_objects");
+  rcl_interfaces::msg::ParameterDescriptor expiration_descriptor;
+  expiration_descriptor.description =
+    "Hard tracker expiry after the last measurement, in seconds. Startup-only.";
+  expiration_descriptor.read_only = true;
+  params_.tracker_expiration_time_s = declare_parameter<double>(
+    "tracker_expiration_time_s", 1.0, expiration_descriptor);
+  if (!std::isfinite(params_.tracker_expiration_time_s) ||
+    params_.tracker_expiration_time_s <= 0.0 || params_.tracker_expiration_time_s > 2.0)
+  {
+    throw std::invalid_argument(
+            "tracker_expiration_time_s must be finite and within (0, 2]");
+  }
+  rcl_interfaces::msg::ParameterDescriptor speed_descriptor;
+  speed_descriptor.description =
+    "Longitudinal speed limit for GeneralVehicle motion models, in m/s. Startup-only.";
+  speed_descriptor.read_only = true;
+  params_.general_vehicle_max_speed_mps = declare_parameter<double>(
+    "general_vehicle_max_speed_mps", 140.0 / 3.6, speed_descriptor);
+  if (!std::isfinite(params_.general_vehicle_max_speed_mps) ||
+    params_.general_vehicle_max_speed_mps <= 0.0 ||
+    params_.general_vehicle_max_speed_mps > 120.0)
+  {
+    throw std::invalid_argument(
+            "general_vehicle_max_speed_mps must be finite and within (0, 120]");
+  }
 
   // define input channel parameters. the channel size is defined by this array.
   constexpr size_t MAX_INPUT_CHANNELS = 12;

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -46,13 +46,28 @@ TrackerProcessor::TrackerProcessor(
   const TrackerAssociationConfig & association_config,
   const TrackerOverlapManagerConfig & tracker_overlap_manager_config,
   const std::vector<types::InputChannel> & channels_config, const rclcpp::Logger & logger,
-  rclcpp::Clock::SharedPtr clock)
+  rclcpp::Clock::SharedPtr clock, const double tracker_expiration_time_s,
+  const double general_vehicle_max_speed_mps)
 : tracker_configs_(tracker_configs),
   creation_config_(creation_config),
   channels_config_(channels_config),
+  tracker_expiration_time_s_(tracker_expiration_time_s),
+  general_vehicle_model_(object_model::ObjectModelType::GeneralVehicle),
   logger_(logger),
   clock_(std::move(clock))
 {
+  if (!std::isfinite(tracker_expiration_time_s_) || tracker_expiration_time_s_ <= 0.0 ||
+    tracker_expiration_time_s_ > 2.0)
+  {
+    throw std::invalid_argument("tracker_expiration_time_s must be finite and within (0, 2]");
+  }
+  if (!std::isfinite(general_vehicle_max_speed_mps) ||
+    general_vehicle_max_speed_mps <= 0.0 || general_vehicle_max_speed_mps > 120.0)
+  {
+    throw std::invalid_argument(
+            "general_vehicle_max_speed_mps must be finite and within (0, 120]");
+  }
+  general_vehicle_model_.process_limit.vel_long_max = general_vehicle_max_speed_mps;
   association_manager_ = std::make_unique<AssociationManager>(association_config, channels_config);
   tracker_overlap_manager_ =
     std::make_unique<TrackerOverlapManager>(tracker_overlap_manager_config);
@@ -523,7 +538,7 @@ std::shared_ptr<Tracker> TrackerProcessor::createNewTracker(
       case types::TrackerType::MULTIPLE_VEHICLE:
         return std::make_shared<MultipleVehicleTracker>(time, object);
       case types::TrackerType::GENERAL_VEHICLE:
-        return std::make_shared<VehicleTracker>(object_model::general_vehicle, time, object);
+        return std::make_shared<VehicleTracker>(general_vehicle_model_, time, object);
       case types::TrackerType::PEDESTRIAN_AND_BICYCLE:
         return std::make_shared<PedestrianAndBicycleTracker>(time, object);
       case types::TrackerType::NORMAL_VEHICLE:
@@ -576,11 +591,13 @@ void TrackerProcessor::removeOldTracker(const rclcpp::Time & time)
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
-  for (auto itr = list_tracker_.begin(); itr != list_tracker_.end(); ++itr) {
-    if ((*itr)->isExpired(time, adaptive_threshold_cache_, getEgoPose())) {
-      auto erase_itr = itr;
-      --itr;
-      list_tracker_.erase(erase_itr);
+  for (auto itr = list_tracker_.begin(); itr != list_tracker_.end();) {
+    if ((*itr)->isExpired(
+        time, adaptive_threshold_cache_, getEgoPose(), tracker_expiration_time_s_))
+    {
+      itr = list_tracker_.erase(itr);
+    } else {
+      ++itr;
     }
   }
 }

--- a/perception/autoware_multi_object_tracker/src/processor/processor.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.hpp
@@ -18,6 +18,7 @@
 #include "autoware/multi_object_tracker/association/adaptive_threshold_cache.hpp"
 #include "autoware/multi_object_tracker/association/association_manager.hpp"
 #include "autoware/multi_object_tracker/association/tracker_overlap_manager.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/tracker/trackers/tracker_base.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 
@@ -45,7 +46,8 @@ public:
     const TrackerAssociationConfig & association_config,
     const TrackerOverlapManagerConfig & tracker_overlap_manager_config,
     const std::vector<types::InputChannel> & channels_config, const rclcpp::Logger & logger,
-    rclcpp::Clock::SharedPtr clock);
+    rclcpp::Clock::SharedPtr clock, double tracker_expiration_time_s = 1.0,
+    double general_vehicle_max_speed_mps = 140.0 / 3.6);
 
   const std::list<std::shared_ptr<Tracker>> & getListTracker() const { return list_tracker_; }
 
@@ -93,6 +95,8 @@ private:
   const TrackerConfigs tracker_configs_;
   const TrackerCreationConfig creation_config_;
   const std::vector<types::InputChannel> & channels_config_;
+  const double tracker_expiration_time_s_;
+  object_model::ObjectModel general_vehicle_model_;
 
   std::optional<geometry_msgs::msg::PoseStamped> ego_pose_;
 

--- a/perception/autoware_multi_object_tracker/test/test_birth_guard.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_birth_guard.cpp
@@ -39,6 +39,51 @@ namespace
 namespace mot = autoware::multi_object_tracker;
 using std::chrono_literals::operator""ms;
 
+mot::types::DynamicObject makeRuntimeLimitCar(
+  const rclcpp::Time & time, const double longitudinal_velocity_mps,
+  const std::string & id)
+{
+  mot::types::DynamicObject object;
+  object.uuid.uuid = stringToUUID(id);
+  object.time = time;
+  object.channel_index = 0;
+  object.existence_probability = 0.95F;
+  object.classification = {{mot::classes::Label::CAR, 1.0F}};
+  object.pose.orientation.w = 1.0;
+  object.pose_covariance.fill(0.0);
+  object.pose_covariance[0] = 0.01;
+  object.pose_covariance[7] = 0.01;
+  object.pose_covariance[35] = 0.01;
+  object.twist.linear.x = longitudinal_velocity_mps;
+  object.twist_covariance.fill(0.0);
+  object.twist_covariance[0] = 0.01;
+  object.twist_covariance[7] = 0.01;
+  object.kinematics.has_position_covariance = true;
+  object.kinematics.orientation_availability = mot::types::OrientationAvailability::AVAILABLE;
+  object.kinematics.has_twist = true;
+  object.kinematics.has_twist_covariance = true;
+  object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  object.shape.dimensions.x = 4.8;
+  object.shape.dimensions.y = 2.0;
+  object.shape.dimensions.z = 1.5;
+  object.area = object.shape.dimensions.x * object.shape.dimensions.y;
+  return object;
+}
+
+void spawnRuntimeLimitCar(
+  mot::TrackerProcessor & processor, const rclcpp::Time & time,
+  const double longitudinal_velocity_mps, const std::string & id)
+{
+  mot::types::DynamicObjectList objects;
+  objects.header.stamp = time;
+  objects.header.frame_id = "map";
+  objects.channel_index = 0;
+  objects.objects.push_back(makeRuntimeLimitCar(time, longitudinal_velocity_mps, id));
+  mot::types::AssociationResult association;
+  const mot::types::AssociatedObjects associated{objects, association};
+  processor.spawn(associated);
+}
+
 class BirthGuardTest : public ::testing::Test
 {
 protected:
@@ -578,6 +623,90 @@ TEST_F(BirthGuardTest, RejectsNonFiniteMeasurementPositions)
 
   process(time, {{30.0, 0.0}});
   EXPECT_EQ(processor_->getListTracker().size(), 1U);
+}
+
+TEST(TrackerRuntimeLimits, ProcessorAppliesConfiguredExpirationTime)
+{
+  const auto tracker_configs = createTrackerConfigs();
+  const auto creation_config = createTrackerCreationConfig();
+  const auto association_config = createTrackerAssociationConfig();
+  const auto overlap_config = createTrackerOverlapManagerConfig();
+  const auto channels = createInputChannelsConfig();
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  constexpr double upstream_expiration_s = 1.0;
+  constexpr double extended_expiration_s = 2.0;
+  constexpr double default_general_vehicle_limit_mps = 140.0 / 3.6;
+  mot::TrackerProcessor upstream_processor(
+    tracker_configs, creation_config, association_config, overlap_config, channels,
+    rclcpp::get_logger("runtime_limits_upstream_expiration_test"), clock,
+    upstream_expiration_s, default_general_vehicle_limit_mps);
+  mot::TrackerProcessor extended_processor(
+    tracker_configs, creation_config, association_config, overlap_config, channels,
+    rclcpp::get_logger("runtime_limits_extended_expiration_test"), clock,
+    extended_expiration_s, default_general_vehicle_limit_mps);
+
+  const rclcpp::Time initial_time{1000000000LL, RCL_ROS_TIME};
+  spawnRuntimeLimitCar(upstream_processor, initial_time, 0.0, "upstream_expiration_1");
+  spawnRuntimeLimitCar(upstream_processor, initial_time, 0.0, "upstream_expiration_2");
+  spawnRuntimeLimitCar(extended_processor, initial_time, 0.0, "extended_expiration_1");
+  spawnRuntimeLimitCar(extended_processor, initial_time, 0.0, "extended_expiration_2");
+  ASSERT_EQ(upstream_processor.getListTracker().size(), 2U);
+  ASSERT_EQ(extended_processor.getListTracker().size(), 2U);
+
+  const auto after_upstream_timeout = initial_time + rclcpp::Duration(1100ms);
+  upstream_processor.prune(after_upstream_timeout);
+  extended_processor.prune(after_upstream_timeout);
+
+  EXPECT_TRUE(upstream_processor.getListTracker().empty());
+  EXPECT_EQ(extended_processor.getListTracker().size(), 2U);
+
+  extended_processor.prune(initial_time + rclcpp::Duration(2100ms));
+  EXPECT_TRUE(extended_processor.getListTracker().empty());
+}
+
+TEST(TrackerRuntimeLimits, ProcessorAppliesConfiguredGeneralVehicleSpeedCap)
+{
+  const auto tracker_configs = createTrackerConfigs();
+  auto creation_config = createTrackerCreationConfig();
+  creation_config.setCreation(
+    mot::types::ShapeType::BOUNDING_BOX, mot::classes::Label::CAR,
+    mot::types::TrackerType::GENERAL_VEHICLE);
+  const auto association_config = createTrackerAssociationConfig();
+  const auto overlap_config = createTrackerOverlapManagerConfig();
+  const auto channels = createInputChannelsConfig();
+  constexpr double tracker_expiration_s = 1.0;
+  constexpr double configured_speed_cap_mps = 100.0;
+  mot::TrackerProcessor processor(
+    tracker_configs, creation_config, association_config, overlap_config, channels,
+    rclcpp::get_logger("runtime_limits_general_vehicle_speed_test"),
+    std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME), tracker_expiration_s,
+    configured_speed_cap_mps);
+
+  const rclcpp::Time initial_time{1000000000LL, RCL_ROS_TIME};
+  spawnRuntimeLimitCar(processor, initial_time, 130.0, "initial_vehicle");
+  ASSERT_EQ(processor.getListTracker().size(), 1U);
+  const auto tracker = processor.getListTracker().front();
+  ASSERT_EQ(tracker->getTrackerType(), mot::types::TrackerType::GENERAL_VEHICLE);
+  mot::types::DynamicObject birth_output;
+  ASSERT_TRUE(tracker->getTrackedObject(initial_time, birth_output, false));
+  EXPECT_NEAR(birth_output.twist.linear.x, configured_speed_cap_mps, 1.0e-6);
+
+  const auto update_time = initial_time + rclcpp::Duration(100ms);
+  ASSERT_TRUE(tracker->predict(update_time));
+  auto measurement = makeRuntimeLimitCar(update_time, 130.0, "fast_measurement");
+  mot::types::DynamicObjectList objects;
+  objects.header.stamp = update_time;
+  objects.header.frame_id = "map";
+  objects.channel_index = 0;
+  objects.objects.push_back(measurement);
+  mot::types::AssociationResult association;
+  association.add(tracker->getUUID(), measurement.uuid);
+  const mot::types::AssociatedObjects associated{objects, association};
+  processor.update(associated);
+
+  mot::types::DynamicObject output;
+  ASSERT_TRUE(tracker->getTrackedObject(update_time, output, false));
+  EXPECT_NEAR(output.twist.linear.x, configured_speed_cap_mps, 1.0e-6);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- expose track coast duration and vehicle speed limits as ROS parameters
- apply the configured limits to tracker birth and update guards
- add defaults, schema entries, and regression coverage

## Testing

- package build completed successfully
- all 5 package CTest targets passed locally